### PR TITLE
fix: typo on end screen

### DIFF
--- a/ui/welcome_screen/WelcomeScreen.tscn
+++ b/ui/welcome_screen/WelcomeScreen.tscn
@@ -343,14 +343,14 @@ You may encounter bugs and typos. We have many improvements and lessons planned.
 
 If you face any problem, please use the button in the top-right to report it to us.
 
-[b]It is crucial[/b]: we'll use your reports and feedback to improve the app, both your you and everyone else."
+[b]It is crucial[/b]: we'll use your reports and feedback to improve the app, both for you and everyone else."
 text = "The app is in beta.
 
 You may encounter bugs and typos. We have many improvements and lessons planned.
 
 If you face any problem, please use the button in the top-right to report it to us.
 
-It is crucial: we'll use your reports and feedback to improve the app, both your you and everyone else."
+It is crucial: we'll use your reports and feedback to improve the app, both for you and everyone else."
 fit_content_height = true
 __meta__ = {
 "_edit_use_anchors_": false


### PR DESCRIPTION
This small PR fixes wrong wording in the welcome screen. 
It changes the word "your" to "for" in the "Early beta release"-infobox.

This should fix issue #123.

Thanks to @duianto for helping me out! :)