### PR TITLE
improvement: confirm quiz type change

### DIFF
--- a/addons/gdscript-course-builder/ui/QuizContentBlock.gd
+++ b/addons/gdscript-course-builder/ui/QuizContentBlock.gd
@@ -17,6 +17,8 @@ const QuizInputFieldScene := preload("QuizInputField.tscn")
 var _quiz: Quiz
 var _list_index := -1
 var _confirm_dialog_mode := -1
+# If cange of quiz type is confirmed, set quiz type to target quiz type option.
+var _change_quiz_type_target := -1
 var _drag_preview_style: StyleBox
 
 onready var _background_panel := $BackgroundPanel as PanelContainer
@@ -189,6 +191,8 @@ func _on_confirm_dialog_confirmed() -> void:
 	match _confirm_dialog_mode:
 		ConfirmMode.REMOVE_BLOCK:
 			emit_signal("block_removed")
+		ConfirmMode.CHANGE_QUIZ_TYPE:
+			_change_quiz_type()
 
 	_confirm_dialog_mode = -1
 
@@ -215,17 +219,21 @@ func _on_explanation_text_edit_text_changed() -> void:
 	_quiz.emit_changed()
 
 
-# TODO: Confirm with confirmation dialog first
 func _on_quiz_type_options_item_selected(index: int) -> void:
-	if index in [ITEM_MULTIPLE_CHOICE, ITEM_SINGLE_CHOICE]:
+	_change_quiz_type_target = index
+	_confirm_dialog_mode = ConfirmMode.CHANGE_QUIZ_TYPE
+	_show_confirm("Are you sure you want to change the quiz type? This may lose all answer data.")
+
+func _change_quiz_type(target: int = _change_quiz_type_target) -> void:
+	if target in [ITEM_MULTIPLE_CHOICE, ITEM_SINGLE_CHOICE]:
 		if _quiz is QuizChoice:
-			_quiz.set_is_multiple_choice(index == ITEM_MULTIPLE_CHOICE)
+			_quiz.set_is_multiple_choice(target == ITEM_MULTIPLE_CHOICE)
 		else:
 			_create_new_quiz_resource(QuizChoice, _quiz)
-	elif index == ITEM_TEXT_INPUT:
+	elif target == ITEM_TEXT_INPUT:
 		_create_new_quiz_resource(QuizInputField, _quiz)
 	else:
-		printerr("Selected unsupported item type: %s" % [index])
+		printerr("Selected unsupported item type: %s" % [target])
 
 
 func _create_new_quiz_resource(new_type, from: Quiz) -> void:

--- a/addons/gdscript-course-builder/ui/QuizContentBlock.gd
+++ b/addons/gdscript-course-builder/ui/QuizContentBlock.gd
@@ -70,7 +70,8 @@ func _ready() -> void:
 	_question_line_edit.connect("text_changed", self, "_on_question_line_edit_text_changed")
 
 	_confirm_dialog.connect("confirmed", self, "_on_confirm_dialog_confirmed")
-
+	_confirm_dialog.get_cancel().connect("pressed", self, "_on_confirm_dialog_cancelled")
+	
 	_quiz_type_options.connect("item_selected", self, "_on_quiz_type_options_item_selected")
 
 	# Update theme items
@@ -194,6 +195,19 @@ func _on_confirm_dialog_confirmed() -> void:
 		ConfirmMode.CHANGE_QUIZ_TYPE:
 			_change_quiz_type()
 
+	_confirm_dialog_mode = -1
+
+func _on_confirm_dialog_cancelled() -> void:
+	if _confirm_dialog_mode == ConfirmMode.CHANGE_QUIZ_TYPE:
+		if _quiz is QuizInputField:
+			_quiz_type_options.selected = 2
+		elif _quiz is QuizChoice:
+			_quiz_type_options.selected = 0 if _quiz.is_multiple_choice else 1
+		else:
+			printerr("Trying to load unsupported quiz type: %s" % [_quiz.get_class()])
+		
+		_change_quiz_type_target = -1
+	
 	_confirm_dialog_mode = -1
 
 

--- a/resources/QuizChoice.gd
+++ b/resources/QuizChoice.gd
@@ -1,6 +1,6 @@
-#Fixes a bug where the Course Builder would not react to the command "set_is_multiple_choice"
-tool
 # Quiz based on a single or multiple choice form.
+# The class is set to tool mode to use it in the Course Builder plugin.
+tool
 class_name QuizChoice
 extends Quiz
 

--- a/resources/QuizChoice.gd
+++ b/resources/QuizChoice.gd
@@ -1,3 +1,5 @@
+#Fixes a bug where the Course Builder would not react to the command "set_is_multiple_choice"
+tool
 # Quiz based on a single or multiple choice form.
 class_name QuizChoice
 extends Quiz


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #20 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Adds 1 variable and 2 new functions to QuizContentBlock.gd.
These are used to confirm with the user that the quiz type change is correct.

QuizChoice now has the "tool" keyword.


**Does this PR introduce a breaking change?**
Not that I'm aware of.


## New feature or change ##


**What is the current behavior?** 
Will proceed to change the quiz type if requested, without asking for confirmation.


**What is the new behavior?**
Will now ask for confirmation about changing the quiz type and warn that current data may be lost.


**Other information**
Fixed a bug where the course builder didn't change the choice type due to QuizChoice not having the tool keyword (able to run in editor).
    (The bug didn't appear when the quiz type was made in the script, but when loaded from file it would not work as intended.)
There might be other similar bugs involved with content edits.