### PR TITLE
fix: use navigate_back transition

### DIFF
--- a/ui/UINavigator.gd
+++ b/ui/UINavigator.gd
@@ -225,7 +225,7 @@ func _on_practice_previous_requested(practice: Practice) -> void:
 		return
 	else:
 		# Otherwise, go to the previous practice in the set.
-		NavigationManager.navigate_to(practices[index - 1].practice_id)
+		NavigationManager.navigate_back()
 
 
 func _on_practice_requested(practice: Practice) -> void:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #227

Replaces `navigate_to(practices[index - 1].practice_id)` with `navigate_back()` to play the correct transition on the "<-" course button.