### PR TITLE
fix: typo "minute" with "moment"

### DIFF
--- a/course/lesson-11-time-delta/lesson.tres
+++ b/course/lesson-11-time-delta/lesson.tres
@@ -185,7 +185,7 @@ has_separator = false
 script = ExtResource( 3 )
 practice_id = "res://course/lesson-11-time-delta/practice-UdOCQiGj.tres"
 title = "Rotating Using Delta"
-goal = "At the minute, the rotation of the robot is frame-dependent.
+goal = "At the moment, the rotation of the robot is frame-dependent.
 
 Add [code]delta[/code] to make the rotational speed time-dependent.
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.

**What kind of change does this PR introduce?**
Fixed a typo.

Before:
>At the minute, the rotation of the robot is frame-dependent.

Changed: `minute` to `moment`

After:
>At the moment, the rotation of the robot is frame-dependent.
