### PR TITLE
improvement: Quiz resize animations

### DIFF
--- a/ui/screens/lesson/UIBaseQuiz.gd
+++ b/ui/screens/lesson/UIBaseQuiz.gd
@@ -12,33 +12,42 @@ const OUTLINE_FLASH_DURATION := 0.8
 const OUTLINE_FLASH_DELAY := 0.75
 const ERROR_SHAKE_TIME := 0.5
 const ERROR_SHAKE_SIZE := 20
+const FADE_OUT_TIME := 0.15
+const FADE_IN_TIME := 0.15
+const INTERPOLATION_TIME := 0.3
 
 export var test_quiz: Resource
 
 var completed_before := false setget set_completed_before
 
 onready var _outline := $Outline as PanelContainer
-onready var _question := $MarginContainer/ChoiceView/QuizHeader/Question as RichTextLabel
-onready var _explanation := $MarginContainer/ResultView/Explanation as RichTextLabel
-onready var _content := $MarginContainer/ChoiceView/Content as RichTextLabel
+onready var _question := $MarginContainer/BoundaryControl/ChoiceView/QuizHeader/Question as RichTextLabel
+onready var _explanation := $MarginContainer/BoundaryControl/ResultView/Explanation as RichTextLabel
+onready var _content := $MarginContainer/BoundaryControl/ChoiceView/Content as RichTextLabel
 onready var _completed_before_icon := (
-	$MarginContainer/ChoiceView/QuizHeader/CompletedBeforeIcon as TextureRect
+	$MarginContainer/BoundaryControl/ChoiceView/QuizHeader/CompletedBeforeIcon as TextureRect
 )
 
-onready var _choice_view := $MarginContainer/ChoiceView as VBoxContainer
-onready var _result_view := $MarginContainer/ResultView as VBoxContainer
+onready var _margin_container := $MarginContainer as MarginContainer
+onready var _boundary_control := $MarginContainer/BoundaryControl as Control
+onready var _choice_view := $MarginContainer/BoundaryControl/ChoiceView as VBoxContainer
+onready var _result_view := $MarginContainer/BoundaryControl/ResultView as VBoxContainer
 
-onready var _submit_button := $MarginContainer/ChoiceView/HBoxContainer/SubmitButton as Button
-onready var _skip_button := $MarginContainer/ChoiceView/HBoxContainer/SkipButton as Button
+onready var _submit_button := $MarginContainer/BoundaryControl/ChoiceView/HBoxContainer/SubmitButton as Button
+onready var _skip_button := $MarginContainer/BoundaryControl/ChoiceView/HBoxContainer/SkipButton as Button
 
-onready var _result_label := $MarginContainer/ResultView/Label as Label
-onready var _correct_answer_label := $MarginContainer/ResultView/CorrectAnswer as Label
+onready var _result_label := $MarginContainer/BoundaryControl/ResultView/Label as Label
+onready var _correct_answer_label := $MarginContainer/BoundaryControl/ResultView/CorrectAnswer as Label
 
 onready var _tween := $Tween as Tween
-onready var _help_message := $MarginContainer/ChoiceView/HelpMessage as Label
+onready var _help_message := $MarginContainer/BoundaryControl/ChoiceView/HelpMessage as Label
 
 var _quiz: Quiz
 var _shake_pos: float = 0
+# For animating changing the size of the container
+var _current_rect_size := rect_size
+var _next_rect_size := Vector2.ZERO
+var _percent_transformed: float = 0
 
 
 func _ready() -> void:
@@ -47,6 +56,11 @@ func _ready() -> void:
 	_submit_button.connect("pressed", self, "_test_answer")
 	_skip_button.connect("pressed", self, "_show_answer", [false])
 	connect("item_rect_changed", self, "_on_item_rect_changed")
+	
+	_choice_view.connect("minimum_size_changed", self, "_on_choice_view_minimum_size_changed")
+	
+	_tween.connect("tween_step", self, "_on_tween_step")
+	_tween.connect("tween_completed", self, "_on_tween_completed")
 
 
 func setup(quiz: Quiz) -> void:
@@ -62,6 +76,8 @@ func setup(quiz: Quiz) -> void:
 
 	_explanation.visible = not _quiz.explanation_bbcode.empty()
 	_explanation.bbcode_text = TextUtils.bbcode_add_code_color(_quiz.explanation_bbcode)
+	
+	rect_min_size = _get_min_size_needed(_choice_view)
 
 
 func set_completed_before(value: bool) -> void:
@@ -115,14 +131,42 @@ func _test_answer() -> void:
 	else:
 		_show_answer()
 
+func _get_min_size_needed(view: Control) -> Vector2:
+	# Adds the minimum size from the view and adds the margins from margincontainer
+	# and a little more for visual integrity (Buttons clip bottom of boundary without)
+	return view.get_combined_minimum_size() + rect_size - _boundary_control.rect_size + Vector2(0, 10)
 
 func _show_answer(gave_correct_answer := true) -> void:
 	_tween.stop_all()
 	_outline.add_stylebox_override("panel", PASSED_OUTLINE if gave_correct_answer else NEUTRAL_OUTLINE)
 	_outline.modulate.a = 1.0
-
+	
+	
 	_result_view.show()
-	_choice_view.hide()
+	
+	_change_rect_size(_get_min_size_needed(_result_view))
+	
+	_tween.interpolate_property(
+		_choice_view,
+		"modulate:a",
+		_choice_view.modulate.a,
+		0,
+		FADE_OUT_TIME
+	)
+	
+	_tween.interpolate_property(
+		_result_view,
+		"modulate:a",
+		0,
+		1,
+		FADE_IN_TIME,
+		Tween.TRANS_LINEAR,
+		Tween.EASE_IN,
+		FADE_OUT_TIME
+	)
+	
+	_tween.start()
+	
 	if gave_correct_answer:
 		emit_signal("quiz_passed")
 	else:
@@ -134,7 +178,42 @@ func _show_answer(gave_correct_answer := true) -> void:
 		_correct_answer_label.text = _quiz.get_correct_answer_string()
 		emit_signal("quiz_skipped")
 
+func _change_rect_size(target: Vector2) -> void:
+	_tween.stop_all()
+	
+	_current_rect_size = rect_min_size
+	_next_rect_size = target
+	_percent_transformed = 0
+	
+	_tween.interpolate_property(
+		self, 
+		"_percent_transformed", 
+		0.0, 
+		1.0,
+		INTERPOLATION_TIME,
+		Tween.TRANS_SINE,
+		Tween.EASE_IN_OUT
+	)
+	
+	_tween.start()
+
+func _on_choice_view_minimum_size_changed() -> void:
+	_change_rect_size(_get_min_size_needed(_choice_view))
+
 
 func _on_item_rect_changed() -> void:
 	if not _tween.is_active() or _tween.tell() > ERROR_SHAKE_TIME:
 		_shake_pos = rect_position.y
+
+func _on_tween_step(object: Object, _key: NodePath, _elapsed: float, _value: Object) -> void:
+	if object == self and _next_rect_size != Vector2.ZERO:
+		var final_size := _current_rect_size
+		var difference := _next_rect_size - _current_rect_size
+		final_size += difference * _percent_transformed
+		rect_min_size = final_size
+
+func _on_tween_completed(_object: Object, key: NodePath) -> void:
+	if key == "_percent_transformed":
+		_current_rect_size = _next_rect_size
+		_next_rect_size = Vector2.ZERO
+		_percent_transformed = 0

--- a/ui/screens/lesson/UIBaseQuiz.gd
+++ b/ui/screens/lesson/UIBaseQuiz.gd
@@ -130,7 +130,10 @@ func _test_answer() -> void:
 		_show_answer()
 
 func _show_answer(gave_correct_answer := true) -> void:
+	# Reset any error animations
 	_tween.stop_all()
+	_tween.reset_all()
+	_tween.remove_all()
 	
 	_outline.add_stylebox_override("panel", PASSED_OUTLINE if gave_correct_answer else NEUTRAL_OUTLINE)
 	_outline.modulate.a = 1.0
@@ -182,6 +185,7 @@ func _get_min_rect_size_needed_to_fit(view: Control) -> Vector2:
 
 func _change_rect_size(target: Vector2) -> void:
 	_tween.stop_all()
+	_tween.remove(self, "_percent_transformed")
 	
 	_current_rect_size = rect_min_size
 	_next_rect_size = target

--- a/ui/screens/lesson/UIBaseQuiz.gd
+++ b/ui/screens/lesson/UIBaseQuiz.gd
@@ -204,13 +204,15 @@ func _on_choice_view_minimum_size_changed() -> void:
 func _on_item_rect_changed() -> void:
 	if not _tween.is_active() or _tween.tell() > ERROR_SHAKE_TIME:
 		_shake_pos = rect_position.y
+	_choice_view.rect_size.x = _boundary_control.rect_size.x
+	_result_view.rect_size.x = _boundary_control.rect_size.x
 
 func _on_tween_step(object: Object, _key: NodePath, _elapsed: float, _value: Object) -> void:
 	if object == self and _next_rect_size != Vector2.ZERO:
-		var final_size := _current_rect_size
+		var new_size := _current_rect_size
 		var difference := _next_rect_size - _current_rect_size
-		final_size += difference * _percent_transformed
-		rect_min_size = final_size
+		new_size += difference * _percent_transformed
+		rect_min_size = new_size
 
 func _on_tween_completed(_object: Object, key: NodePath) -> void:
 	if key == "_percent_transformed":

--- a/ui/screens/lesson/UIBaseQuiz.gd
+++ b/ui/screens/lesson/UIBaseQuiz.gd
@@ -48,7 +48,7 @@ var _shake_pos: float = 0
 # For animating changing the size of the container
 var _previous_rect_size := rect_size
 var _next_rect_size := Vector2.ZERO
-var _percent_transformed: float = 0
+var _percent_transformed := 0.0
 
 
 func _ready() -> void:

--- a/ui/screens/lesson/UIBaseQuiz.gd
+++ b/ui/screens/lesson/UIBaseQuiz.gd
@@ -223,7 +223,7 @@ func _on_item_rect_changed() -> void:
 
 func _on_size_tween_step(object: Object, key: NodePath, _elapsed: float, _value: Object) -> void:
 	if object == self and key == ":_percent_transformed":
-		#_next_rect_size = _get_minimum_rect_size_needed_to_fit(_next_view)
+		_next_rect_size = _get_minimum_rect_size_needed_to_fit(_next_view)
 		var new_size := _current_rect_size
 		var difference := _next_rect_size - _current_rect_size
 		new_size += difference * _percent_transformed

--- a/ui/screens/lesson/UIBaseQuiz.gd
+++ b/ui/screens/lesson/UIBaseQuiz.gd
@@ -205,6 +205,7 @@ func _change_rect_size_to_fit(view: Control) -> void:
 # Needed for updating post-initialization.
 # Will also animate expanding the container to fit a hint upon _help_message.show()
 func _on_choice_view_resized() -> void:
+	_choice_view.rect_size.y = 0 # Wacky workaround for size errors with rich text labels.
 	if _choice_view.visible:
 		_change_rect_size_to_fit(_choice_view)
 

--- a/ui/screens/lesson/UIBaseQuiz.tscn
+++ b/ui/screens/lesson/UIBaseQuiz.tscn
@@ -11,9 +11,9 @@
 [ext_resource path="res://ui/theme/button_outlined_normal.tres" type="StyleBox" id=9]
 
 [node name="UIBaseQuiz" type="PanelContainer"]
-margin_right = 101.0
-margin_bottom = 94.0
-rect_min_size = Vector2( 400, 0 )
+margin_right = 400.0
+margin_bottom = 202.0
+rect_min_size = Vector2( 400, 1 )
 theme = ExtResource( 4 )
 custom_styles/panel = ExtResource( 3 )
 script = ExtResource( 6 )
@@ -29,21 +29,32 @@ margin_bottom = 202.0
 [node name="MarginContainer" type="MarginContainer" parent="."]
 margin_right = 400.0
 margin_bottom = 202.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
-[node name="ChoiceView" type="VBoxContainer" parent="MarginContainer"]
+[node name="BoundaryControl" type="Control" parent="MarginContainer"]
 margin_left = 20.0
 margin_top = 20.0
 margin_right = 380.0
 margin_bottom = 182.0
+rect_clip_content = true
 
-[node name="QuizHeader" type="HBoxContainer" parent="MarginContainer/ChoiceView"]
+[node name="ChoiceView" type="VBoxContainer" parent="MarginContainer/BoundaryControl"]
+margin_right = 360.0
+margin_bottom = 162.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="QuizHeader" type="HBoxContainer" parent="MarginContainer/BoundaryControl/ChoiceView"]
 margin_right = 360.0
 margin_bottom = 30.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Question" type="RichTextLabel" parent="MarginContainer/ChoiceView/QuizHeader"]
+[node name="Question" type="RichTextLabel" parent="MarginContainer/BoundaryControl/ChoiceView/QuizHeader"]
 margin_right = 320.0
 margin_bottom = 30.0
 rect_min_size = Vector2( 0, 30 )
@@ -55,7 +66,7 @@ text = "Question"
 fit_content_height = true
 scroll_active = false
 
-[node name="CompletedBeforeIcon" type="TextureRect" parent="MarginContainer/ChoiceView/QuizHeader"]
+[node name="CompletedBeforeIcon" type="TextureRect" parent="MarginContainer/BoundaryControl/ChoiceView/QuizHeader"]
 modulate = Color( 1, 1, 1, 0.235294 )
 margin_left = 336.0
 margin_right = 360.0
@@ -67,7 +78,7 @@ texture = ExtResource( 5 )
 expand = true
 stretch_mode = 6
 
-[node name="Content" type="RichTextLabel" parent="MarginContainer/ChoiceView"]
+[node name="Content" type="RichTextLabel" parent="MarginContainer/BoundaryControl/ChoiceView"]
 margin_top = 46.0
 margin_right = 360.0
 margin_bottom = 75.0
@@ -77,18 +88,18 @@ bbcode_text = "Explanation"
 text = "Explanation"
 fit_content_height = true
 
-[node name="Answers" type="VBoxContainer" parent="MarginContainer/ChoiceView"]
+[node name="Answers" type="VBoxContainer" parent="MarginContainer/BoundaryControl/ChoiceView"]
 margin_top = 91.0
 margin_right = 360.0
 margin_bottom = 91.0
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/ChoiceView"]
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/BoundaryControl/ChoiceView"]
 margin_top = 107.0
 margin_right = 360.0
 margin_bottom = 162.0
 alignment = 1
 
-[node name="SubmitButton" type="Button" parent="MarginContainer/ChoiceView/HBoxContainer"]
+[node name="SubmitButton" type="Button" parent="MarginContainer/BoundaryControl/ChoiceView/HBoxContainer"]
 margin_left = 52.0
 margin_right = 172.0
 margin_bottom = 55.0
@@ -99,7 +110,7 @@ custom_styles/pressed = ExtResource( 8 )
 custom_styles/normal = ExtResource( 9 )
 text = "Submit"
 
-[node name="SkipButton" type="Button" parent="MarginContainer/ChoiceView/HBoxContainer"]
+[node name="SkipButton" type="Button" parent="MarginContainer/BoundaryControl/ChoiceView/HBoxContainer"]
 margin_left = 188.0
 margin_right = 308.0
 margin_bottom = 55.0
@@ -112,30 +123,33 @@ custom_styles/normal = ExtResource( 9 )
 disabled = true
 text = "Skip"
 
-[node name="HelpMessage" type="Label" parent="MarginContainer/ChoiceView"]
+[node name="HelpMessage" type="Label" parent="MarginContainer/BoundaryControl/ChoiceView"]
 visible = false
-margin_top = 208.0
+margin_top = 178.0
 margin_right = 360.0
-margin_bottom = 236.0
+margin_bottom = 206.0
 custom_colors/font_color = Color( 0.14902, 0.776471, 0.968627, 1 )
 autowrap = true
 
-[node name="ResultView" type="VBoxContainer" parent="MarginContainer"]
+[node name="ResultView" type="VBoxContainer" parent="MarginContainer/BoundaryControl"]
 visible = false
-margin_left = 20.0
-margin_top = 20.0
-margin_right = 380.0
-margin_bottom = 182.0
+modulate = Color( 1, 1, 1, 0 )
+margin_right = 360.0
+margin_bottom = 162.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
-[node name="Label" type="Label" parent="MarginContainer/ResultView"]
+[node name="Label" type="Label" parent="MarginContainer/BoundaryControl/ResultView"]
 margin_right = 360.0
 margin_bottom = 26.0
 custom_colors/font_color = Color( 0.960784, 0.980392, 0.980392, 1 )
 custom_fonts/font = ExtResource( 1 )
 text = "You're right!"
 
-[node name="CorrectAnswer" type="Label" parent="MarginContainer/ResultView"]
+[node name="CorrectAnswer" type="Label" parent="MarginContainer/BoundaryControl/ResultView"]
 visible = false
+modulate = Color( 1, 1, 1, 0 )
 margin_top = 42.0
 margin_right = 600.0
 margin_bottom = 70.0
@@ -145,10 +159,10 @@ custom_fonts/font = ExtResource( 2 )
 text = "Answers here"
 autowrap = true
 
-[node name="Explanation" type="RichTextLabel" parent="MarginContainer/ResultView"]
+[node name="Explanation" type="RichTextLabel" parent="MarginContainer/BoundaryControl/ResultView"]
 margin_top = 42.0
 margin_right = 360.0
-margin_bottom = 71.0
+margin_bottom = 162.0
 size_flags_vertical = 3
 bbcode_enabled = true
 bbcode_text = "Explanation"

--- a/ui/screens/lesson/UIBaseQuiz.tscn
+++ b/ui/screens/lesson/UIBaseQuiz.tscn
@@ -149,7 +149,6 @@ text = "You're right!"
 
 [node name="CorrectAnswer" type="Label" parent="MarginContainer/BoundaryControl/ResultView"]
 visible = false
-modulate = Color( 1, 1, 1, 0 )
 margin_top = 42.0
 margin_right = 600.0
 margin_bottom = 70.0

--- a/ui/screens/lesson/UIBaseQuiz.tscn
+++ b/ui/screens/lesson/UIBaseQuiz.tscn
@@ -135,7 +135,7 @@ autowrap = true
 visible = false
 modulate = Color( 1, 1, 1, 0 )
 margin_right = 360.0
-margin_bottom = 162.0
+margin_bottom = 75.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -162,7 +162,7 @@ autowrap = true
 [node name="Explanation" type="RichTextLabel" parent="MarginContainer/BoundaryControl/ResultView"]
 margin_top = 42.0
 margin_right = 360.0
-margin_bottom = 162.0
+margin_bottom = 71.0
 size_flags_vertical = 3
 bbcode_enabled = true
 bbcode_text = "Explanation"

--- a/ui/screens/lesson/UIBaseQuiz.tscn
+++ b/ui/screens/lesson/UIBaseQuiz.tscn
@@ -169,4 +169,6 @@ bbcode_text = "Explanation"
 text = "Explanation"
 fit_content_height = true
 
-[node name="Tween" type="Tween" parent="."]
+[node name="SizeTween" type="Tween" parent="."]
+
+[node name="ErrorTween" type="Tween" parent="."]

--- a/ui/screens/lesson/quizzes/UIQuizChoice.gd
+++ b/ui/screens/lesson/quizzes/UIQuizChoice.gd
@@ -4,7 +4,7 @@ extends UIBaseQuiz
 const QuizAnswerButtonScene := preload("res://ui/screens/lesson/quizzes/QuizAnswerButton.tscn")
 
 
-onready var _choices := $MarginContainer/ChoiceView/Answers as VBoxContainer
+onready var _choices := $MarginContainer/BoundaryControl/ChoiceView/Answers as VBoxContainer
 
 
 func _ready() -> void:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #15 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Animates resizes of Quiz content blocks. Reacts upon any change of choice view or result view and will proceed to fit (if they are visible).


**Does this PR introduce a breaking change?**
No


## New feature or change ##


**What is the current behavior?** 
Instantaneous jumps to new size.


**What is the new behavior?**
Animated size changes of rectangle size to fit the current view.


**Other information**
Letters sometimes gets a black line over them for no apparent reason. Not sure if this is created on my own pc running this or if this is introduced by BoundaryControl. Affects text on quiz answer elements and quiz label.

You can see the quiz unfolding itself if you scroll fast enough. (I couldn't find a way to set the correct size without waiting for the views to update with the loaded content.)

Some answers with long text might wrap around once selected and increase the size of the view creating a slightly weird looking reaction by the container. (Not breaking anything, looks normal after .5 seconds)

Will work with hints when implemented.