### PR TITLE
fix: typo "want to want to"

### DIFF
--- a/course/lesson-13-conditions/lesson.tres
+++ b/course/lesson-13-conditions/lesson.tres
@@ -269,7 +269,7 @@ practice_id = "res://course/lesson-13-conditions/practice-xZPxY8VU.tres"
 title = "Preventing Health from Going Below Zero"
 goal = "When the robot takes damage, its health can be negative.
 
-We might want to want to display the health number on screen, like in Japanese RPGs.
+We might want to display the health number on screen, like in Japanese RPGs.
 
 We don't want negative numbers: we want instead to stop at zero.
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.

**What kind of change does this PR introduce?**

Fixed a typo.

Before:
We might want to want to display the health number on screen, like in Japanese RPGs.

Change: "want to want to" -> "want to"

After:
We might want to display the health number on screen, like in Japanese RPGs.
