### PR TITLE
fix: missing space between a nr and modulo sign

### DIFF
--- a/course/lesson-15-modulo/lesson.tres
+++ b/course/lesson-15-modulo/lesson.tres
@@ -30,7 +30,7 @@ content_bbcode = "[code]11 % 4[/code]"
 hint = ""
 explanation_bbcode = "[code]11[/code] divided by [code]4[/code] is [code]2[/code], and the [b]remainder[/b] of the division is [code]3[/code].
 
-So [code]11% 4[/code] is [code]3[/code]."
+So [code]11 % 4[/code] is [code]3[/code]."
 answer_options = [ "3", "2", "7" ]
 valid_answers = [ "3" ]
 is_multiple_choice = false
@@ -147,7 +147,7 @@ script = ExtResource( 5 )
 content_id = "res://course/lesson-15-modulo/content-c7DDizKU.tres"
 title = ""
 type = 0
-text = "Notice how the modulo can be larger than the number it affects. For example, [code]1% 2[/code] gives you [code]1[/code]. That's because [code]1[/code] divided by [code]2[/code] equals [code]0[/code], and the remainder is [code]1[/code].
+text = "Notice how the modulo can be larger than the number it affects. For example, [code]1 % 2[/code] gives you [code]1[/code]. That's because [code]1[/code] divided by [code]2[/code] equals [code]0[/code], and the remainder is [code]1[/code].
 
 Like with divisions, the only case you can't use modulo is with a divisor of [code]0[/code]."
 visual_element_path = ""


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.

**What kind of change does this PR introduce?**
Fix typos.

Before: `So 11% 4 is 3`
After: `So 11 % 4 is 3`

And:
Before: `For example, 1% 2 gives you 1.`
After: `For example, 1 % 2 gives you 1.`
