### PR TITLE
fix: traffic light colors, match example and text

### DIFF
--- a/course/lesson-15-modulo/lesson.tres
+++ b/course/lesson-15-modulo/lesson.tres
@@ -89,7 +89,7 @@ title = ""
 type = 0
 text = "We use the number [code]light_index[/code] to represent the traffic light's current state.
 
-The lights always cycle in the same way: first, we have the green light, then the orange, then the red.
+The lights always cycle in the same way: first, we have the red light, then the orange, then the green.
 
 To represent that cycle, you can periodically add one to the number and use the modulo operator to wrap back to [code]0[/code].
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.

**What kind of change does this PR introduce?**

Corrects the lesson text, so that it matches the example it's referring to.

In lesson 15:
https://gdquest.github.io/learn-gdscript/staging/#course/lesson-15-modulo/lesson.tres

Under the heading: `Three ways we use the modulo operation`

The example shows a traffic light.
Pressing the `Advance` button.
Cycles the lights from: `Red` to `Orange` to `Green`
then it repeats from `Red`

But the text below the example describes the color order as:
> The lights always cycle in the same way: first, we have the green light, then the orange, then the red.

**Expected**

The description, after matching the order in the example, results in:
> The lights always cycle in the same way: first, we have the red light, then the orange, then the green.
