### PR TITLE
improvement: animate quiz resizing

### DIFF
--- a/ui/screens/lesson/UIBaseQuiz.gd
+++ b/ui/screens/lesson/UIBaseQuiz.gd
@@ -12,8 +12,8 @@ const OUTLINE_FLASH_DURATION := 0.8
 const OUTLINE_FLASH_DELAY := 0.75
 const ERROR_SHAKE_TIME := 0.5
 const ERROR_SHAKE_SIZE := 20
-const FADE_IN_TIME := 0.2
-const FADE_OUT_TIME := 0.2
+const FADE_IN_TIME := 0.3
+const FADE_OUT_TIME := 0.3
 const SIZE_CHANGE_TIME := 0.5
 
 export var test_quiz: Resource
@@ -138,7 +138,7 @@ func _show_answer(gave_correct_answer := true) -> void:
 
 	_result_view.show()
 	
-	#Hiding choice view upon completion of following tween
+	#Hiding choice view upon completion of the following tween
 	_size_tween.interpolate_property(
 		_choice_view,
 		"modulate:a",
@@ -198,17 +198,17 @@ func _on_item_rect_changed() -> void:
 		_margin_container.rect_size.x = rect_size.x
 
 func _on_margin_container_minimum_size_changed() -> void:
-	# Force margin container into it's minimum size.
 	if _margin_container.rect_size.y > _margin_container.get_combined_minimum_size().y:
-		_margin_container.rect_size.y = 0
+		_margin_container.rect_size.y = _margin_container.get_combined_minimum_size().y
 	
-	if not _size_tween.is_active() or _size_tween.tell() > SIZE_CHANGE_TIME * 0.8:
+	# The if statement is to avoid any pausing effects in resizing to result view
+	# It will, however, jump if any element is rapidly changing size inside the margin container. 
+	if not _size_tween.is_active() or _size_tween.tell() > SIZE_CHANGE_TIME:
 		_change_rect_size_to_fit(_margin_container.rect_size)
 	else:
-		# Avoid jittering if this happens due to choice view being hidden
 		_next_rect_size = _margin_container.rect_size
 
-# This is here to update after being visible.
+# This is here to update container size after result view becomes visible.
 func _on_result_view_minimum_size_changed() -> void:
 	if _result_view.visible:
 		var margins := _margin_container.rect_size - _result_view.rect_size
@@ -224,6 +224,7 @@ func _on_size_tween_step(object: Object, key: NodePath, _elapsed: float, _value:
 func _on_size_tween_completed(object: Object, key: NodePath) -> void:
 	if object == self and key == ":_percent_transformed":
 		_next_rect_size = Vector2.ZERO
+	
 	# To avoid the buttons being clickable after choice view is gone.
 	if object == _choice_view and key == ":modulate:a":
 		_choice_view.hide()

--- a/ui/screens/lesson/UIBaseQuiz.gd
+++ b/ui/screens/lesson/UIBaseQuiz.gd
@@ -18,24 +18,25 @@ export var test_quiz: Resource
 var completed_before := false setget set_completed_before
 
 onready var _outline := $Outline as PanelContainer
-onready var _question := $MarginContainer/ChoiceView/QuizHeader/Question as RichTextLabel
-onready var _explanation := $MarginContainer/ResultView/Explanation as RichTextLabel
-onready var _content := $MarginContainer/ChoiceView/Content as RichTextLabel
+onready var _question := $ClipContentBoundary/MarginContainer/ChoiceView/QuizHeader/Question as RichTextLabel
+onready var _explanation := $ClipContentBoundary/MarginContainer/ResultView/Explanation as RichTextLabel
+onready var _content := $ClipContentBoundary/MarginContainer/ChoiceView/Content as RichTextLabel
 onready var _completed_before_icon := (
-	$MarginContainer/ChoiceView/QuizHeader/CompletedBeforeIcon as TextureRect
+	$ClipContentBoundary/MarginContainer/ChoiceView/QuizHeader/CompletedBeforeIcon as TextureRect
 )
 
-onready var _choice_view := $MarginContainer/ChoiceView as VBoxContainer
-onready var _result_view := $MarginContainer/ResultView as VBoxContainer
+onready var _margin_container := $ClipContentBoundary/MarginContainer as MarginContainer
+onready var _choice_view := $ClipContentBoundary/MarginContainer/ChoiceView as VBoxContainer
+onready var _result_view := $ClipContentBoundary/MarginContainer/ResultView as VBoxContainer
 
-onready var _submit_button := $MarginContainer/ChoiceView/HBoxContainer/SubmitButton as Button
-onready var _skip_button := $MarginContainer/ChoiceView/HBoxContainer/SkipButton as Button
+onready var _submit_button := $ClipContentBoundary/MarginContainer/ChoiceView/HBoxContainer/SubmitButton as Button
+onready var _skip_button := $ClipContentBoundary/MarginContainer/ChoiceView/HBoxContainer/SkipButton as Button
 
-onready var _result_label := $MarginContainer/ResultView/Label as Label
-onready var _correct_answer_label := $MarginContainer/ResultView/CorrectAnswer as Label
+onready var _result_label := $ClipContentBoundary/MarginContainer/ResultView/Label as Label
+onready var _correct_answer_label := $ClipContentBoundary/MarginContainer/ResultView/CorrectAnswer as Label
 
 onready var _tween := $Tween as Tween
-onready var _help_message := $MarginContainer/ChoiceView/HelpMessage as Label
+onready var _help_message := $ClipContentBoundary/MarginContainer/ChoiceView/HelpMessage as Label
 
 var _quiz: Quiz
 var _shake_pos: float = 0
@@ -47,6 +48,9 @@ func _ready() -> void:
 	_submit_button.connect("pressed", self, "_test_answer")
 	_skip_button.connect("pressed", self, "_show_answer", [false])
 	connect("item_rect_changed", self, "_on_item_rect_changed")
+	
+	#_margin_container.connect("resized", self, "_on_margin_container_resized")
+	_margin_container.connect("minimum_size_changed", self, "_on_margin_container_minimum_size_changed")
 
 
 func setup(quiz: Quiz) -> void:
@@ -134,7 +138,18 @@ func _show_answer(gave_correct_answer := true) -> void:
 		_correct_answer_label.text = _quiz.get_correct_answer_string()
 		emit_signal("quiz_skipped")
 
+func _change_rect_size_to_fit(view: Control):
+	rect_min_size = view.rect_size
 
 func _on_item_rect_changed() -> void:
 	if not _tween.is_active() or _tween.tell() > ERROR_SHAKE_TIME:
 		_shake_pos = rect_position.y
+	if _margin_container.rect_size.x < rect_size.x:
+		_margin_container.rect_size.x = rect_size.x
+	if _margin_container.rect_size.y > _margin_container.get_combined_minimum_size().y:
+		_margin_container.rect_size.y = 0
+		
+func _on_margin_container_minimum_size_changed():
+	if _margin_container.rect_size.y > _margin_container.get_combined_minimum_size().y:
+		_margin_container.rect_size.y = 0
+	_change_rect_size_to_fit(_margin_container)

--- a/ui/screens/lesson/UIBaseQuiz.gd
+++ b/ui/screens/lesson/UIBaseQuiz.gd
@@ -57,9 +57,9 @@ func _ready() -> void:
 	_skip_button.connect("pressed", self, "_show_answer", [false])
 	connect("item_rect_changed", self, "_on_item_rect_changed")
 	
-	#_margin_container.connect("resized", self, "_on_margin_container_resized")
 	_margin_container.connect("minimum_size_changed", self, "_on_margin_container_minimum_size_changed")
 	_result_view.connect("minimum_size_changed", self, "_on_result_view_minimum_size_changed")
+	
 	_size_tween.connect("tween_step", self, "_on_size_tween_step")
 	_size_tween.connect("tween_completed", self, "_on_size_tween_completed")
 
@@ -171,7 +171,7 @@ func _show_answer(gave_correct_answer := true) -> void:
 		_correct_answer_label.text = _quiz.get_correct_answer_string()
 		emit_signal("quiz_skipped")
 
-func _change_rect_size_to_fit(size: Vector2):
+func _change_rect_size_to_fit(size: Vector2) -> void:
 	_size_tween.stop_all()
 	
 	_previous_rect_size = rect_min_size
@@ -197,7 +197,7 @@ func _on_item_rect_changed() -> void:
 	if _margin_container.rect_size.x < rect_size.x:
 		_margin_container.rect_size.x = rect_size.x
 
-func _on_margin_container_minimum_size_changed():
+func _on_margin_container_minimum_size_changed() -> void:
 	# Force margin container into it's minimum size.
 	if _margin_container.rect_size.y > _margin_container.get_combined_minimum_size().y:
 		_margin_container.rect_size.y = 0
@@ -209,7 +209,7 @@ func _on_margin_container_minimum_size_changed():
 		_next_rect_size = _margin_container.rect_size
 
 # This is here to update after being visible.
-func _on_result_view_minimum_size_changed():
+func _on_result_view_minimum_size_changed() -> void:
 	if _result_view.visible:
 		var margins := _margin_container.rect_size - _result_view.rect_size
 		_change_rect_size_to_fit(_result_view.get_combined_minimum_size() + margins)
@@ -221,7 +221,7 @@ func _on_size_tween_step(object: Object, key: NodePath, _elapsed: float, _value:
 		new_size += difference * _percent_transformed
 		rect_min_size = new_size
 
-func _on_size_tween_completed(object: Object, key: NodePath):
+func _on_size_tween_completed(object: Object, key: NodePath) -> void:
 	if object == self and key == ":_percent_transformed":
 		_next_rect_size = Vector2.ZERO
 	# To avoid the buttons being clickable after choice view is gone.

--- a/ui/screens/lesson/UIBaseQuiz.tscn
+++ b/ui/screens/lesson/UIBaseQuiz.tscn
@@ -11,8 +11,8 @@
 [ext_resource path="res://ui/theme/button_outlined_normal.tres" type="StyleBox" id=9]
 
 [node name="UIBaseQuiz" type="PanelContainer"]
-margin_right = 101.0
-margin_bottom = 94.0
+margin_right = 400.0
+margin_bottom = 202.0
 rect_min_size = Vector2( 400, 0 )
 theme = ExtResource( 4 )
 custom_styles/panel = ExtResource( 3 )
@@ -26,24 +26,32 @@ modulate = Color( 1, 1, 1, 0 )
 margin_right = 400.0
 margin_bottom = 202.0
 
-[node name="MarginContainer" type="MarginContainer" parent="."]
+[node name="ClipContentBoundary" type="Control" parent="."]
 margin_right = 400.0
 margin_bottom = 202.0
+rect_clip_content = true
 
-[node name="ChoiceView" type="VBoxContainer" parent="MarginContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="ClipContentBoundary"]
+margin_right = 400.0
+margin_bottom = 202.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="ChoiceView" type="VBoxContainer" parent="ClipContentBoundary/MarginContainer"]
 margin_left = 20.0
 margin_top = 20.0
 margin_right = 380.0
 margin_bottom = 182.0
 
-[node name="QuizHeader" type="HBoxContainer" parent="MarginContainer/ChoiceView"]
+[node name="QuizHeader" type="HBoxContainer" parent="ClipContentBoundary/MarginContainer/ChoiceView"]
 margin_right = 360.0
 margin_bottom = 30.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Question" type="RichTextLabel" parent="MarginContainer/ChoiceView/QuizHeader"]
+[node name="Question" type="RichTextLabel" parent="ClipContentBoundary/MarginContainer/ChoiceView/QuizHeader"]
 margin_right = 320.0
 margin_bottom = 30.0
 rect_min_size = Vector2( 0, 30 )
@@ -55,7 +63,7 @@ text = "Question"
 fit_content_height = true
 scroll_active = false
 
-[node name="CompletedBeforeIcon" type="TextureRect" parent="MarginContainer/ChoiceView/QuizHeader"]
+[node name="CompletedBeforeIcon" type="TextureRect" parent="ClipContentBoundary/MarginContainer/ChoiceView/QuizHeader"]
 modulate = Color( 1, 1, 1, 0.235294 )
 margin_left = 336.0
 margin_right = 360.0
@@ -67,7 +75,7 @@ texture = ExtResource( 5 )
 expand = true
 stretch_mode = 6
 
-[node name="Content" type="RichTextLabel" parent="MarginContainer/ChoiceView"]
+[node name="Content" type="RichTextLabel" parent="ClipContentBoundary/MarginContainer/ChoiceView"]
 margin_top = 46.0
 margin_right = 360.0
 margin_bottom = 75.0
@@ -77,18 +85,18 @@ bbcode_text = "Explanation"
 text = "Explanation"
 fit_content_height = true
 
-[node name="Answers" type="VBoxContainer" parent="MarginContainer/ChoiceView"]
+[node name="Answers" type="VBoxContainer" parent="ClipContentBoundary/MarginContainer/ChoiceView"]
 margin_top = 91.0
 margin_right = 360.0
 margin_bottom = 91.0
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/ChoiceView"]
+[node name="HBoxContainer" type="HBoxContainer" parent="ClipContentBoundary/MarginContainer/ChoiceView"]
 margin_top = 107.0
 margin_right = 360.0
 margin_bottom = 162.0
 alignment = 1
 
-[node name="SubmitButton" type="Button" parent="MarginContainer/ChoiceView/HBoxContainer"]
+[node name="SubmitButton" type="Button" parent="ClipContentBoundary/MarginContainer/ChoiceView/HBoxContainer"]
 margin_left = 52.0
 margin_right = 172.0
 margin_bottom = 55.0
@@ -99,7 +107,7 @@ custom_styles/pressed = ExtResource( 8 )
 custom_styles/normal = ExtResource( 9 )
 text = "Submit"
 
-[node name="SkipButton" type="Button" parent="MarginContainer/ChoiceView/HBoxContainer"]
+[node name="SkipButton" type="Button" parent="ClipContentBoundary/MarginContainer/ChoiceView/HBoxContainer"]
 margin_left = 188.0
 margin_right = 308.0
 margin_bottom = 55.0
@@ -112,7 +120,7 @@ custom_styles/normal = ExtResource( 9 )
 disabled = true
 text = "Skip"
 
-[node name="HelpMessage" type="Label" parent="MarginContainer/ChoiceView"]
+[node name="HelpMessage" type="Label" parent="ClipContentBoundary/MarginContainer/ChoiceView"]
 visible = false
 margin_top = 208.0
 margin_right = 360.0
@@ -120,21 +128,21 @@ margin_bottom = 236.0
 custom_colors/font_color = Color( 0.14902, 0.776471, 0.968627, 1 )
 autowrap = true
 
-[node name="ResultView" type="VBoxContainer" parent="MarginContainer"]
+[node name="ResultView" type="VBoxContainer" parent="ClipContentBoundary/MarginContainer"]
 visible = false
 margin_left = 20.0
 margin_top = 20.0
 margin_right = 380.0
 margin_bottom = 182.0
 
-[node name="Label" type="Label" parent="MarginContainer/ResultView"]
+[node name="Label" type="Label" parent="ClipContentBoundary/MarginContainer/ResultView"]
 margin_right = 360.0
 margin_bottom = 26.0
 custom_colors/font_color = Color( 0.960784, 0.980392, 0.980392, 1 )
 custom_fonts/font = ExtResource( 1 )
 text = "You're right!"
 
-[node name="CorrectAnswer" type="Label" parent="MarginContainer/ResultView"]
+[node name="CorrectAnswer" type="Label" parent="ClipContentBoundary/MarginContainer/ResultView"]
 visible = false
 margin_top = 42.0
 margin_right = 600.0
@@ -145,7 +153,7 @@ custom_fonts/font = ExtResource( 2 )
 text = "Answers here"
 autowrap = true
 
-[node name="Explanation" type="RichTextLabel" parent="MarginContainer/ResultView"]
+[node name="Explanation" type="RichTextLabel" parent="ClipContentBoundary/MarginContainer/ResultView"]
 margin_top = 42.0
 margin_right = 360.0
 margin_bottom = 71.0

--- a/ui/screens/lesson/UIBaseQuiz.tscn
+++ b/ui/screens/lesson/UIBaseQuiz.tscn
@@ -31,27 +31,28 @@ margin_right = 400.0
 margin_bottom = 202.0
 rect_clip_content = true
 
-[node name="MarginContainer" type="MarginContainer" parent="ClipContentBoundary"]
+[node name="ChoiceContainer" type="MarginContainer" parent="ClipContentBoundary"]
 margin_right = 400.0
 margin_bottom = 202.0
+rect_clip_content = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="ChoiceView" type="VBoxContainer" parent="ClipContentBoundary/MarginContainer"]
+[node name="ChoiceView" type="VBoxContainer" parent="ClipContentBoundary/ChoiceContainer"]
 margin_left = 20.0
 margin_top = 20.0
 margin_right = 380.0
 margin_bottom = 182.0
 
-[node name="QuizHeader" type="HBoxContainer" parent="ClipContentBoundary/MarginContainer/ChoiceView"]
+[node name="QuizHeader" type="HBoxContainer" parent="ClipContentBoundary/ChoiceContainer/ChoiceView"]
 margin_right = 360.0
 margin_bottom = 30.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Question" type="RichTextLabel" parent="ClipContentBoundary/MarginContainer/ChoiceView/QuizHeader"]
+[node name="Question" type="RichTextLabel" parent="ClipContentBoundary/ChoiceContainer/ChoiceView/QuizHeader"]
 margin_right = 320.0
 margin_bottom = 30.0
 rect_min_size = Vector2( 0, 30 )
@@ -63,7 +64,7 @@ text = "Question"
 fit_content_height = true
 scroll_active = false
 
-[node name="CompletedBeforeIcon" type="TextureRect" parent="ClipContentBoundary/MarginContainer/ChoiceView/QuizHeader"]
+[node name="CompletedBeforeIcon" type="TextureRect" parent="ClipContentBoundary/ChoiceContainer/ChoiceView/QuizHeader"]
 modulate = Color( 1, 1, 1, 0.235294 )
 margin_left = 336.0
 margin_right = 360.0
@@ -75,7 +76,7 @@ texture = ExtResource( 5 )
 expand = true
 stretch_mode = 6
 
-[node name="Content" type="RichTextLabel" parent="ClipContentBoundary/MarginContainer/ChoiceView"]
+[node name="Content" type="RichTextLabel" parent="ClipContentBoundary/ChoiceContainer/ChoiceView"]
 margin_top = 46.0
 margin_right = 360.0
 margin_bottom = 75.0
@@ -85,18 +86,18 @@ bbcode_text = "Explanation"
 text = "Explanation"
 fit_content_height = true
 
-[node name="Answers" type="VBoxContainer" parent="ClipContentBoundary/MarginContainer/ChoiceView"]
+[node name="Answers" type="VBoxContainer" parent="ClipContentBoundary/ChoiceContainer/ChoiceView"]
 margin_top = 91.0
 margin_right = 360.0
 margin_bottom = 91.0
 
-[node name="HBoxContainer" type="HBoxContainer" parent="ClipContentBoundary/MarginContainer/ChoiceView"]
+[node name="HBoxContainer" type="HBoxContainer" parent="ClipContentBoundary/ChoiceContainer/ChoiceView"]
 margin_top = 107.0
 margin_right = 360.0
 margin_bottom = 162.0
 alignment = 1
 
-[node name="SubmitButton" type="Button" parent="ClipContentBoundary/MarginContainer/ChoiceView/HBoxContainer"]
+[node name="SubmitButton" type="Button" parent="ClipContentBoundary/ChoiceContainer/ChoiceView/HBoxContainer"]
 margin_left = 52.0
 margin_right = 172.0
 margin_bottom = 55.0
@@ -107,7 +108,7 @@ custom_styles/pressed = ExtResource( 8 )
 custom_styles/normal = ExtResource( 9 )
 text = "Submit"
 
-[node name="SkipButton" type="Button" parent="ClipContentBoundary/MarginContainer/ChoiceView/HBoxContainer"]
+[node name="SkipButton" type="Button" parent="ClipContentBoundary/ChoiceContainer/ChoiceView/HBoxContainer"]
 margin_left = 188.0
 margin_right = 308.0
 margin_bottom = 55.0
@@ -120,7 +121,7 @@ custom_styles/normal = ExtResource( 9 )
 disabled = true
 text = "Skip"
 
-[node name="HelpMessage" type="Label" parent="ClipContentBoundary/MarginContainer/ChoiceView"]
+[node name="HelpMessage" type="Label" parent="ClipContentBoundary/ChoiceContainer/ChoiceView"]
 visible = false
 margin_top = 208.0
 margin_right = 360.0
@@ -128,22 +129,30 @@ margin_bottom = 236.0
 custom_colors/font_color = Color( 0.14902, 0.776471, 0.968627, 1 )
 autowrap = true
 
-[node name="ResultView" type="VBoxContainer" parent="ClipContentBoundary/MarginContainer"]
+[node name="ResultContainer" type="MarginContainer" parent="ClipContentBoundary"]
 visible = false
 modulate = Color( 1, 1, 1, 0 )
+margin_right = 400.0
+margin_bottom = 111.0
+rect_clip_content = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="ResultView" type="VBoxContainer" parent="ClipContentBoundary/ResultContainer"]
 margin_left = 20.0
 margin_top = 20.0
 margin_right = 380.0
-margin_bottom = 182.0
+margin_bottom = 91.0
 
-[node name="Label" type="Label" parent="ClipContentBoundary/MarginContainer/ResultView"]
+[node name="Label" type="Label" parent="ClipContentBoundary/ResultContainer/ResultView"]
 margin_right = 360.0
 margin_bottom = 26.0
 custom_colors/font_color = Color( 0.960784, 0.980392, 0.980392, 1 )
 custom_fonts/font = ExtResource( 1 )
 text = "You're right!"
 
-[node name="CorrectAnswer" type="Label" parent="ClipContentBoundary/MarginContainer/ResultView"]
+[node name="CorrectAnswer" type="Label" parent="ClipContentBoundary/ResultContainer/ResultView"]
 visible = false
 margin_top = 42.0
 margin_right = 600.0
@@ -154,7 +163,7 @@ custom_fonts/font = ExtResource( 2 )
 text = "Answers here"
 autowrap = true
 
-[node name="Explanation" type="RichTextLabel" parent="ClipContentBoundary/MarginContainer/ResultView"]
+[node name="Explanation" type="RichTextLabel" parent="ClipContentBoundary/ResultContainer/ResultView"]
 margin_top = 42.0
 margin_right = 360.0
 margin_bottom = 71.0

--- a/ui/screens/lesson/UIBaseQuiz.tscn
+++ b/ui/screens/lesson/UIBaseQuiz.tscn
@@ -163,4 +163,6 @@ bbcode_text = "Explanation"
 text = "Explanation"
 fit_content_height = true
 
-[node name="Tween" type="Tween" parent="."]
+[node name="ErrorTween" type="Tween" parent="."]
+
+[node name="SizeTween" type="Tween" parent="."]

--- a/ui/screens/lesson/UIBaseQuiz.tscn
+++ b/ui/screens/lesson/UIBaseQuiz.tscn
@@ -130,6 +130,7 @@ autowrap = true
 
 [node name="ResultView" type="VBoxContainer" parent="ClipContentBoundary/MarginContainer"]
 visible = false
+modulate = Color( 1, 1, 1, 0 )
 margin_left = 20.0
 margin_top = 20.0
 margin_right = 380.0

--- a/ui/screens/lesson/quizzes/UIQuizChoice.gd
+++ b/ui/screens/lesson/quizzes/UIQuizChoice.gd
@@ -4,7 +4,7 @@ extends UIBaseQuiz
 const QuizAnswerButtonScene := preload("res://ui/screens/lesson/quizzes/QuizAnswerButton.tscn")
 
 
-onready var _choices := $MarginContainer/ChoiceView/Answers as VBoxContainer
+onready var _choices := $ClipContentBoundary/MarginContainer/ChoiceView/Answers as VBoxContainer
 
 
 func _ready() -> void:

--- a/ui/screens/lesson/quizzes/UIQuizChoice.gd
+++ b/ui/screens/lesson/quizzes/UIQuizChoice.gd
@@ -4,7 +4,7 @@ extends UIBaseQuiz
 const QuizAnswerButtonScene := preload("res://ui/screens/lesson/quizzes/QuizAnswerButton.tscn")
 
 
-onready var _choices := $ClipContentBoundary/MarginContainer/ChoiceView/Answers as VBoxContainer
+onready var _choices := $ClipContentBoundary/ChoiceContainer/ChoiceView/Answers as VBoxContainer
 
 
 func _ready() -> void:

--- a/ui/screens/lesson/quizzes/UIQuizInputField.gd
+++ b/ui/screens/lesson/quizzes/UIQuizInputField.gd
@@ -1,7 +1,7 @@
 class_name UIQuizInputField
 extends UIBaseQuiz
 
-onready var _line_edit := $MarginContainer/ChoiceView/Answers/LineEdit as LineEdit
+onready var _line_edit := $ClipContentBoundary/MarginContainer/ChoiceView/Answers/LineEdit as LineEdit
 
 
 func _ready() -> void:

--- a/ui/screens/lesson/quizzes/UIQuizInputField.gd
+++ b/ui/screens/lesson/quizzes/UIQuizInputField.gd
@@ -1,7 +1,7 @@
 class_name UIQuizInputField
 extends UIBaseQuiz
 
-onready var _line_edit := $ClipContentBoundary/MarginContainer/ChoiceView/Answers/LineEdit as LineEdit
+onready var _line_edit := $ClipContentBoundary/ChoiceContainer/ChoiceView/Answers/LineEdit as LineEdit
 
 
 func _ready() -> void:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #15 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Animates resizes of Quiz content blocks. Reacts upon any change of choice view or result view and will proceed to fit (if they are visible).
Almost the same as #234 except with proper spacing on some content.

This PR changes the Quiz Base UI to use a Control node with clip content on to contain margin containers. It reacts to the minimum size changes of the margin containers to determine the size it's supposed to animate to.



**Does this PR introduce a breaking change?**
No


## New feature or change ##


**What is the current behavior?** 
Instantaneous jumps to new size.


**What is the new behavior?**
Animated size changes of rectangle size to fit the current view.


**Other information**
There are now 2 margin containers to ensure that one view doesn't affect the size of the other view. This helps remove guesswork from resizing animations. (And massively improves readability of the code.)