### PR TITLE
fix: lesson 9 and 13 health bars now show proper values on ready

### DIFF
--- a/course/lesson-13-conditions/visuals/HealSprite.gd
+++ b/course/lesson-13-conditions/visuals/HealSprite.gd
@@ -4,6 +4,7 @@ export var health := 100
 export var max_health := 100
 export var health_gained := 25
 
+onready var _empty_health_bar := $HealthBar/HealthBarEmpty as ColorRect
 onready var _health_bar := $HealthBar/HealthBarCurrent as ColorRect
 onready var _label := $HealthBar/Label as Label
 onready var _tween := $Tween as Tween
@@ -11,7 +12,7 @@ onready var _animation_player := $AnimationPlayer as AnimationPlayer
 
 
 func _ready() -> void:
-	_health_bar.rect_size.x = health * 2
+	_health_bar.rect_size.x = _empty_health_bar.rect_size.x
 	_update_health_bar()
 
 
@@ -32,7 +33,7 @@ func reset() -> void:
 
 func _update_health_bar() -> void:
 	var size_current = _health_bar.rect_size.x
-	var size_to = 190.0 * health / max_health
+	var size_to = _empty_health_bar.rect_size.x
 	
 	_label.text = "health = %s" % [health]
 	

--- a/course/lesson-13-conditions/visuals/HealSprite.gd
+++ b/course/lesson-13-conditions/visuals/HealSprite.gd
@@ -12,7 +12,7 @@ onready var _animation_player := $AnimationPlayer as AnimationPlayer
 
 
 func _ready() -> void:
-	_health_bar.rect_size.x = _empty_health_bar.rect_size.x
+	_health_bar.rect_size.x = _empty_health_bar.rect_size.x * health / max_health
 	_update_health_bar()
 
 
@@ -33,7 +33,7 @@ func reset() -> void:
 
 func _update_health_bar() -> void:
 	var size_current = _health_bar.rect_size.x
-	var size_to = _empty_health_bar.rect_size.x
+	var size_to = _empty_health_bar.rect_size.x * health / max_health
 	
 	_label.text = "health = %s" % [health]
 	

--- a/course/lesson-9-adding-and-subtracting/visuals/RobotCharacter.gd
+++ b/course/lesson-9-adding-and-subtracting/visuals/RobotCharacter.gd
@@ -14,7 +14,7 @@ onready var _animation_player := $AnimationPlayer as AnimationPlayer
 
 func _ready() -> void:
 	_start_health = health
-	_health_bar.rect_size.x = _empty_health_bar.rect_size.x
+	_health_bar.rect_size.x = _empty_health_bar.rect_size.x * health / max_health
 	_update_health_bar()
 
 
@@ -33,7 +33,7 @@ func reset() -> void:
 
 func _update_health_bar() -> void:
 	var size_current = _health_bar.rect_size.x
-	var size_to = _empty_health_bar.rect_size.x
+	var size_to = _empty_health_bar.rect_size.x * health / max_health
 	
 	_label.text = "health = %s" % [health]
 	

--- a/course/lesson-9-adding-and-subtracting/visuals/RobotCharacter.gd
+++ b/course/lesson-9-adding-and-subtracting/visuals/RobotCharacter.gd
@@ -5,6 +5,7 @@ export var max_health := 100
 
 var _start_health := 0
 
+onready var _empty_health_bar := $HealthBar/HealthBarEmpty as ColorRect
 onready var _health_bar := $HealthBar/HealthBarCurrent as ColorRect
 onready var _label := $HealthBar/Label as Label
 onready var _tween := $Tween as Tween
@@ -13,7 +14,7 @@ onready var _animation_player := $AnimationPlayer as AnimationPlayer
 
 func _ready() -> void:
 	_start_health = health
-	_health_bar.rect_size.x = health * 2
+	_health_bar.rect_size.x = _empty_health_bar.rect_size.x
 	_update_health_bar()
 
 
@@ -32,7 +33,7 @@ func reset() -> void:
 
 func _update_health_bar() -> void:
 	var size_current = _health_bar.rect_size.x
-	var size_to = 190.0 * health / max_health
+	var size_to = _empty_health_bar.rect_size.x
 	
 	_label.text = "health = %s" % [health]
 	


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #220 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Ensures that the health bars in lesson 9 and 13 show correct values when loaded in. 
For some reason the tween doesn't update it on load so it has to be set manually at first.


**Does this PR introduce a breaking change?**
No