### PR TITLE
fix: lesson 8 practice 1 error message will now show that the variable is a string if it's wrong

### DIFF
--- a/course/lesson-8-defining-variables/define-health-variable/TestHasHealthVar.gd
+++ b/course/lesson-8-defining-variables/define-health-variable/TestHasHealthVar.gd
@@ -21,6 +21,9 @@ func test_health_has_value_of_100() -> String:
 	if not has_health_prop:
 		return "Health variable doesn't exist, can't test if it has a value of 100."
 	var health_value = first_node.get("health")
-	if health_value == 100:
+	if health_value is int and health_value == 100:
 		return ""
+	# Ensure proper visualization in case of string input
+	if health_value is String:
+		health_value = '"' + health_value + '"'
 	return "Health variable's value is %s; It should be 100." % health_value


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #258 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Adds quotation marks '"' at the beginning and end of any string element should it be detected as a variable in the practice of lesson 8.


**Does this PR introduce a breaking change?**
No
