### PR TITLE
fix: added further checks to lesson 5 practice 2 with better error messages

### DIFF
--- a/course/lesson-5-your-first-function/TestsDrawingThreeSquares.gd
+++ b/course/lesson-5-your-first-function/TestsDrawingThreeSquares.gd
@@ -27,6 +27,18 @@ func test_draw_square_of_200_pixels() -> String:
 	var index := 1
 	for p in polygons:
 		var points = Array(p.get_points())
+		
+		if points.size() < target_polygon.size():
+			return(
+				"Shape number %s has too few corners! Did you change the draw_square() function?"
+				% index
+			)
+		elif points.size() > target_polygon.size():
+			return(
+				"Shape number %s has too many corners! Did you change the draw_square() function?"
+				% index
+			)
+		
 		# We make all points absolute in case the user turns counter-clockwise when
 		# making the shape.
 		for i in points.size():


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #256 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Adds a check to practice 2 in lesson 5 that will determine if there are too few or too many points in the polygon, showing a similar, yet more precise error message. Note that the user must have made 3 polygons for this to happen.
Most of these boil down to the draw_square function having been rewritten or draw square being called more than once in a row (with 3 successful polygons). Though I doubt the second reason would happen normally, hence why the error message asks for if the draw square function has been rewritten, and not if it was called twice.


**Does this PR introduce a breaking change?**
No