### PR TITLE
improvement: added warning to student when attempting to leave a Practice screen with edited code.

### DIFF
--- a/autoload/Events.gd
+++ b/autoload/Events.gd
@@ -13,6 +13,7 @@ signal practice_completed(practice)
 signal practice_next_requested(practice)
 signal practice_previous_requested(practice)
 signal practice_requested(practice)
+signal breadcrumbs_navigation_requested(path)
 signal course_completed(course)
 
 signal settings_requested

--- a/ui/UINavigator.tscn
+++ b/ui/UINavigator.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=2]
+[gd_scene load_steps=14 format=2]
 
 [ext_resource path="res://ui/theme/gdscript_app_theme.tres" type="Theme" id=1]
 [ext_resource path="res://ui/components/BreadCrumbs.tscn" type="PackedScene" id=2]
@@ -12,6 +12,7 @@
 [ext_resource path="res://ui/icons/icon_godot_head.svg" type="Texture" id=10]
 [ext_resource path="res://ui/components/FullScreenButton.tscn" type="PackedScene" id=11]
 [ext_resource path="res://ui/components/popups/LessonDonePopup.tscn" type="PackedScene" id=12]
+[ext_resource path="res://ui/components/popups/LeaveUnsavedPracticePopup.tscn" type="PackedScene" id=13]
 
 [node name="UINavigator" type="PanelContainer"]
 anchor_right = 1.0
@@ -131,6 +132,12 @@ __meta__ = {
 
 [node name="CourseOutliner" parent="Layout/Content" instance=ExtResource( 7 )]
 visible = false
+
+[node name="LeaveUnsavedPracticePopup" parent="." instance=ExtResource( 13 )]
+visible = false
+title = "Leave unfinished practice?"
+text_content = "You will lose your progress on this practice!"
+strict = true
 
 [node name="LessonDonePopup" parent="." instance=ExtResource( 12 )]
 visible = false

--- a/ui/components/BreadCrumbs.gd
+++ b/ui/components/BreadCrumbs.gd
@@ -97,4 +97,5 @@ func _on_navigation_pressed(path: String) -> void:
 	if path.empty():
 		return
 
-	NavigationManager.navigate_to(path)
+	#NavigationManager.navigate_to(path)
+	Events.emit_signal("breadcrumbs_navigation_requested", path)

--- a/ui/components/popups/LeaveUnsavedPracticePopup.gd
+++ b/ui/components/popups/LeaveUnsavedPracticePopup.gd
@@ -1,0 +1,17 @@
+tool
+extends ConfirmPopup
+
+# Contains UINavigator.NAVIGATION_REQUEST_TYPE and a payload
+# TODO: Create a NavigationRequest class that handles this?
+var _navigation_type := -1
+var _payload := []
+
+func set_navigation_data(type: int, payload: Array) -> void:
+	_navigation_type = type
+	_payload = payload
+
+func get_navigation_type() -> int:
+	return _navigation_type
+	
+func get_payload() -> Array:
+	return _payload

--- a/ui/components/popups/LeaveUnsavedPracticePopup.tscn
+++ b/ui/components/popups/LeaveUnsavedPracticePopup.tscn
@@ -1,0 +1,148 @@
+[gd_scene load_steps=10 format=2]
+
+[ext_resource path="res://ui/components/popups/LeaveUnsavedPracticePopup.gd" type="Script" id=1]
+[ext_resource path="res://ui/theme/fonts/font_title.tres" type="DynamicFont" id=2]
+[ext_resource path="res://ui/theme/button_outline_large_pressed.tres" type="StyleBox" id=3]
+[ext_resource path="res://ui/theme/button_outline_large_normal.tres" type="StyleBox" id=4]
+[ext_resource path="res://ui/theme/panel_normal.tres" type="StyleBox" id=5]
+[ext_resource path="res://ui/theme/button_outline_large_hover.tres" type="StyleBox" id=6]
+[ext_resource path="res://ui/theme/gdscript_app_theme.tres" type="Theme" id=7]
+
+[sub_resource type="StyleBoxFlat" id=1]
+bg_color = Color( 0.239216, 1, 0.431373, 1 )
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+
+[sub_resource type="StyleBoxFlat" id=2]
+content_margin_left = 8.0
+content_margin_right = 8.0
+content_margin_top = 8.0
+content_margin_bottom = 8.0
+bg_color = Color( 0.239216, 1, 0.431373, 1 )
+border_color = Color( 0.572549, 0.560784, 0.721569, 1 )
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_right = 8
+corner_radius_bottom_left = 8
+
+[node name="LeaveUnsavedPracticePopup" type="ColorRect"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color( 0.0352941, 0.0392157, 0.129412, 0.627451 )
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+title = ""
+text_content = ""
+min_size = Vector2( 200, 120 )
+strict = false
+
+[node name="PanelContainer" type="PanelContainer" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -228.0
+margin_top = -115.5
+margin_right = 228.0
+margin_bottom = 115.5
+rect_min_size = Vector2( 200, 120 )
+theme = ExtResource( 7 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Panel" type="Panel" parent="PanelContainer"]
+margin_right = 456.0
+margin_bottom = 260.0
+custom_styles/panel = ExtResource( 5 )
+
+[node name="Column" type="VBoxContainer" parent="PanelContainer"]
+margin_right = 456.0
+margin_bottom = 260.0
+custom_constants/separation = 0
+
+[node name="ProgressBar" type="ProgressBar" parent="PanelContainer/Column"]
+margin_right = 456.0
+margin_bottom = 16.0
+rect_min_size = Vector2( 0, 16 )
+custom_styles/fg = SubResource( 1 )
+value = 100.0
+percent_visible = false
+
+[node name="Margin" type="MarginContainer" parent="PanelContainer/Column"]
+margin_top = 16.0
+margin_right = 456.0
+margin_bottom = 260.0
+size_flags_vertical = 3
+
+[node name="Column" type="VBoxContainer" parent="PanelContainer/Column/Margin"]
+margin_left = 20.0
+margin_top = 20.0
+margin_right = 436.0
+margin_bottom = 224.0
+custom_constants/separation = 12
+
+[node name="Title" type="Label" parent="PanelContainer/Column/Margin/Column"]
+margin_right = 416.0
+margin_bottom = 31.0
+custom_fonts/font = ExtResource( 2 )
+align = 1
+
+[node name="Separator" type="HSeparator" parent="PanelContainer/Column/Margin/Column"]
+margin_left = 8.0
+margin_top = 43.0
+margin_right = 408.0
+margin_bottom = 51.0
+rect_min_size = Vector2( 400, 0 )
+size_flags_horizontal = 4
+
+[node name="Message" type="RichTextLabel" parent="PanelContainer/Column/Margin/Column"]
+margin_top = 63.0
+margin_right = 416.0
+margin_bottom = 92.0
+size_flags_vertical = 3
+bbcode_enabled = true
+fit_content_height = true
+
+[node name="Spacer" type="Control" parent="PanelContainer/Column/Margin/Column"]
+margin_top = 104.0
+margin_right = 416.0
+margin_bottom = 124.0
+rect_min_size = Vector2( 400, 20 )
+
+[node name="Buttons" type="HBoxContainer" parent="PanelContainer/Column/Margin/Column"]
+margin_top = 136.0
+margin_right = 416.0
+margin_bottom = 204.0
+alignment = 1
+
+[node name="ConfirmButton" type="Button" parent="PanelContainer/Column/Margin/Column/Buttons"]
+margin_right = 200.0
+margin_bottom = 68.0
+rect_min_size = Vector2( 200, 68 )
+mouse_default_cursor_shape = 2
+size_flags_horizontal = 4
+custom_colors/font_color = Color( 0.188235, 0.188235, 0.286275, 1 )
+custom_colors/font_color_hover = Color( 0.74902, 0.741176, 0.85098, 1 )
+custom_colors/font_color_pressed = Color( 0.290196, 0.294118, 0.388235, 1 )
+custom_styles/hover = ExtResource( 6 )
+custom_styles/pressed = ExtResource( 3 )
+custom_styles/normal = SubResource( 2 )
+text = "Confirm"
+
+[node name="CancelButton" type="Button" parent="PanelContainer/Column/Margin/Column/Buttons"]
+margin_left = 216.0
+margin_right = 416.0
+margin_bottom = 68.0
+rect_min_size = Vector2( 200, 68 )
+mouse_default_cursor_shape = 2
+size_flags_horizontal = 4
+custom_colors/font_color = Color( 0.572549, 0.560784, 0.721569, 1 )
+custom_colors/font_color_hover = Color( 0.74902, 0.741176, 0.85098, 1 )
+custom_colors/font_color_pressed = Color( 0.290196, 0.294118, 0.388235, 1 )
+custom_styles/hover = ExtResource( 6 )
+custom_styles/pressed = ExtResource( 3 )
+custom_styles/normal = ExtResource( 4 )
+text = "Cancel"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [ ] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #9 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
If the student attempts to leave the practice (through any means given to them), it will ask for confirmation before performing the navigation. This happens if the code in the practice has changed and is not finished.


**Does this PR introduce a breaking change?**
Currently maybe. 
Not properly tested yet (and I need to search the code for signal listeners - might want to add a few extra listeners to Events if I find anything).


## New feature or change ##


**What is the current behavior?** 
The practice screen immediately proceeds forward with the navigation request even if this means the student loses data.


**What is the new behavior?**
The practice screen will ask for confirmation (with warnings) before proceeding.


**Other information**
Currently, it is set to warn students that they will lose their data if they change practice, but they won't. The data is still loaded into history, so if the back button is pressed they will return to the last practice with the data intact.

It will also warn students who finished the practice, but stayed and changed the code later.

It feels like this commit adds more load time to every practice, though I'm not exactly sure *how* (Since nothing about the actual loading has been changed).