### PR TITLE
Fix Web version not being exported by CI.

### DIFF
--- a/.github/workflows/ExportGodot.yaml
+++ b/.github/workflows/ExportGodot.yaml
@@ -106,9 +106,9 @@ jobs:
         with:
           lfs: true
       - run: ./run prepare:ci
-      - if: ${{ github.ref == 'refs/heads/release' }}
-        run: ./run export:web
-      - run: ./run push web
+      - run: ./run export:web
+      - if: ${{ env.git_branch == 'release' }}
+        run: ./run push web
       - name: Deploy to GitHub Pages 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:


### PR DESCRIPTION
Always `run export:web`
Always update gh-pages (the appropriate folder seem to be updated).
Only update the itch.io version (push) in release branch.

**Please check if the PR fulfills these requirements:**

- [ ] The commit message follows our guidelines.
- For bug fixes and features:
    - [ ] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #328 

**What is the new behavior?**

Always `run export:web`
Always update gh-pages (the appropriate folder seem to be updated).
Only update the itch.io version (push) in release branch.