### PR TITLE
fix(lesson10): Pick correct node to check in validation script

### DIFF
--- a/course/lesson-10-the-game-loop/rotating-and-moving/TestsRotatingAndMoving.gd
+++ b/course/lesson-10-the-game-loop/rotating-and-moving/TestsRotatingAndMoving.gd
@@ -1,13 +1,10 @@
 extends PracticeTester
 
 
-func test_character_is_moving_in_a_circle() -> String:
-	var node_2d = _scene_root_viewport.get_child(0).get_child(0)
-	var node_rotation = node_2d.rotation
-	var node_position = node_2d.position as Vector2
-	
-	if node_rotation < 0.0:
+func test_character_is_moving_in_a_circle_clockwise() -> String:
+	var robot: Node2D = _scene_root_viewport.get_child(0).get_node("Robot")
+	if robot.rotation < 0.0:
 		return tr("The robot is turning in the wrong direction!")
-	elif is_equal_approx(node_position.x, 300.0):
+	elif is_equal_approx(robot.position.x, 300.0):
 		return tr("The character didn't move as expected.")
 	return ""

--- a/course/lesson-10-the-game-loop/rotating-sprite/TestsRotating.gd
+++ b/course/lesson-10-the-game-loop/rotating-sprite/TestsRotating.gd
@@ -2,8 +2,7 @@ extends PracticeTester
 
 
 func test_character_is_rotating_clockwise() -> String:
-	var node_2d = _scene_root_viewport.get_child(0).get_child(0)
-	var node_rotation = node_2d.rotation
-	if node_rotation < 0.0:
+	var robot: Node2D = _scene_root_viewport.get_child(0).get_node("Robot")
+	if robot.rotation < 0.0:
 		return tr("The robot is turning in the wrong direction!")
 	return ""


### PR DESCRIPTION
`_scene_root_viewport.get_child(0).get_child(0)` is returning the camera node so the validation scripts wouldn't work properly. This PR checks the correct node by retrieving it with `get_node()`