### PR TITLE
improve: make button theme consistent & less confusing

### DIFF
--- a/ui/UICore.tscn
+++ b/ui/UICore.tscn
@@ -15,9 +15,6 @@ anchor_bottom = 1.0
 mouse_filter = 2
 theme = ExtResource( 2 )
 script = ExtResource( 4 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Pages" type="Control" parent="."]
 anchor_right = 1.0

--- a/ui/components/BigGreenButton.tscn
+++ b/ui/components/BigGreenButton.tscn
@@ -1,6 +1,5 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=6 format=2]
 
-[ext_resource path="res://ui/theme/button_outline_large_hover.tres" type="StyleBox" id=1]
 [ext_resource path="res://ui/theme/button_outline_large_pressed.tres" type="StyleBox" id=2]
 [ext_resource path="res://ui/theme/button_outline_large_focus.tres" type="StyleBox" id=3]
 [ext_resource path="res://ui/theme/fonts/font_button_big_green.tres" type="DynamicFont" id=4]
@@ -15,16 +14,15 @@ rect_min_size = Vector2( 0, 80 )
 mouse_default_cursor_shape = 2
 custom_colors/font_color_focus = Color( 0.960784, 0.980392, 0.980392, 1 )
 custom_colors/font_color = Color( 0.239216, 1, 0.431373, 1 )
-custom_colors/font_color_hover = Color( 0.74902, 0.741176, 0.85098, 1 )
+custom_colors/font_color_hover = Color( 0.960784, 0.980392, 0.980392, 1 )
 custom_colors/font_color_pressed = Color( 0.290196, 0.294118, 0.388235, 1 )
 custom_fonts/font = ExtResource( 4 )
-custom_styles/hover = ExtResource( 1 )
+custom_styles/hover = ExtResource( 3 )
 custom_styles/pressed = ExtResource( 2 )
 custom_styles/focus = ExtResource( 3 )
 custom_styles/normal = ExtResource( 6 )
 text = "Button"
 script = ExtResource( 5 )
 __meta__ = {
-"_edit_use_anchors_": false,
 "_editor_description_": ""
 }

--- a/ui/components/BigGreenButton.tscn
+++ b/ui/components/BigGreenButton.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=6 format=2]
 
+[ext_resource path="res://ui/theme/button_outline_large_normal.tres" type="StyleBox" id=1]
 [ext_resource path="res://ui/theme/button_outline_large_pressed.tres" type="StyleBox" id=2]
-[ext_resource path="res://ui/theme/button_outline_large_focus.tres" type="StyleBox" id=3]
 [ext_resource path="res://ui/theme/fonts/font_button_big_green.tres" type="DynamicFont" id=4]
 [ext_resource path="res://ui/components/BigGreenButton.gd" type="Script" id=5]
 [ext_resource path="res://ui/theme/button_outline_large_accented.tres" type="StyleBox" id=6]
@@ -12,15 +12,15 @@ margin_right = 356.0
 margin_bottom = 976.0
 rect_min_size = Vector2( 0, 80 )
 mouse_default_cursor_shape = 2
-custom_colors/font_color_focus = Color( 0.960784, 0.980392, 0.980392, 1 )
-custom_colors/font_color = Color( 0.239216, 1, 0.431373, 1 )
-custom_colors/font_color_hover = Color( 0.960784, 0.980392, 0.980392, 1 )
+custom_colors/font_color_focus = Color( 0.239216, 1, 0.431373, 1 )
+custom_colors/font_color = Color( 0.572549, 0.560784, 0.721569, 1 )
+custom_colors/font_color_hover = Color( 0.239216, 1, 0.431373, 1 )
 custom_colors/font_color_pressed = Color( 0.290196, 0.294118, 0.388235, 1 )
 custom_fonts/font = ExtResource( 4 )
-custom_styles/hover = ExtResource( 3 )
+custom_styles/hover = ExtResource( 6 )
 custom_styles/pressed = ExtResource( 2 )
-custom_styles/focus = ExtResource( 3 )
-custom_styles/normal = ExtResource( 6 )
+custom_styles/focus = ExtResource( 6 )
+custom_styles/normal = ExtResource( 1 )
 text = "Button"
 script = ExtResource( 5 )
 __meta__ = {

--- a/ui/components/CodeEditor.tscn
+++ b/ui/components/CodeEditor.tscn
@@ -67,9 +67,6 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme = ExtResource( 7 )
 script = ExtResource( 6 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Column" type="VBoxContainer" parent="."]
 margin_right = 1920.0

--- a/ui/components/popups/ConfirmPopup.gd
+++ b/ui/components/popups/ConfirmPopup.gd
@@ -6,6 +6,8 @@ signal confirmed
 
 const STRICT_COLOR := Color(1, 0.094118, 0.321569)
 const NORMAL_COLOR := Color(0.239216, 1, 0.431373)
+const STRICT_STYLEBOX := preload("res://ui/theme/button_outline_large_error.tres")
+const NORMAL_STYLEBOX := preload("res://ui/theme/button_outline_large_accented.tres")
 
 export var title := "" setget set_title
 export(String, MULTILINE) var text_content := "" setget set_text_content
@@ -79,7 +81,11 @@ func _update_top_bar() -> void:
 	if not is_inside_tree():
 		return
 	
-	var highlight_color = STRICT_COLOR if strict else NORMAL_COLOR
+	var highlight_color = NORMAL_COLOR
+	var button_stylebox = NORMAL_STYLEBOX
+	if strict:
+		highlight_color = STRICT_COLOR
+		button_stylebox = STRICT_STYLEBOX
 	
 	var bar_style := _top_bar.get_stylebox("fg").duplicate()
 	if bar_style is StyleBoxFlat:
@@ -90,3 +96,7 @@ func _update_top_bar() -> void:
 	if button_style is StyleBoxFlat:
 		var button_style_box := button_style as StyleBoxFlat
 	_confirm_button.add_stylebox_override("normal", button_style)
+	_confirm_button.add_stylebox_override("focus", button_stylebox)
+	_confirm_button.add_stylebox_override("hover", button_stylebox)
+	_confirm_button.add_color_override("font_color_focus", highlight_color)
+	_confirm_button.add_color_override("font_color_hover", highlight_color)

--- a/ui/components/popups/ConfirmPopup.tscn
+++ b/ui/components/popups/ConfirmPopup.tscn
@@ -5,7 +5,6 @@
 [ext_resource path="res://ui/theme/button_outline_large_pressed.tres" type="StyleBox" id=3]
 [ext_resource path="res://ui/theme/button_outline_large_normal.tres" type="StyleBox" id=4]
 [ext_resource path="res://ui/theme/panel_normal.tres" type="StyleBox" id=5]
-[ext_resource path="res://ui/theme/button_outline_large_hover.tres" type="StyleBox" id=6]
 [ext_resource path="res://ui/theme/gdscript_app_theme.tres" type="Theme" id=7]
 [ext_resource path="res://ui/theme/button_outline_large_focus.tres" type="StyleBox" id=8]
 [ext_resource path="res://ui/theme/button_outline_large_accented.tres" type="StyleBox" id=9]
@@ -15,14 +14,27 @@ bg_color = Color( 0.239216, 1, 0.431373, 1 )
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 
+[sub_resource type="StyleBoxFlat" id=2]
+content_margin_left = 8.0
+content_margin_right = 8.0
+content_margin_top = 8.0
+content_margin_bottom = 8.0
+bg_color = Color( 0.0784314, 0.0823529, 0.164706, 1 )
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color( 0.572549, 0.560784, 0.721569, 1 )
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_right = 8
+corner_radius_bottom_left = 8
+
 [node name="ConfirmPopup" type="ColorRect"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 color = Color( 0.0352941, 0.0392157, 0.129412, 0.627451 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 min_size = Vector2( 0, 0 )
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
@@ -109,13 +121,14 @@ margin_bottom = 68.0
 rect_min_size = Vector2( 200, 68 )
 mouse_default_cursor_shape = 2
 size_flags_horizontal = 4
-custom_colors/font_color = Color( 0.239216, 1, 0.431373, 1 )
-custom_colors/font_color_hover = Color( 0.74902, 0.741176, 0.85098, 1 )
+custom_colors/font_color_focus = Color( 0.239216, 1, 0.431373, 1 )
+custom_colors/font_color = Color( 0.572549, 0.560784, 0.721569, 1 )
+custom_colors/font_color_hover = Color( 0.239216, 1, 0.431373, 1 )
 custom_colors/font_color_pressed = Color( 0.290196, 0.294118, 0.388235, 1 )
-custom_styles/hover = ExtResource( 6 )
+custom_styles/hover = ExtResource( 9 )
 custom_styles/pressed = ExtResource( 3 )
-custom_styles/focus = ExtResource( 8 )
-custom_styles/normal = ExtResource( 9 )
+custom_styles/focus = ExtResource( 9 )
+custom_styles/normal = SubResource( 2 )
 text = "Confirm"
 
 [node name="CancelButton" type="Button" parent="PanelContainer/Column/Margin/Column/Buttons"]
@@ -125,10 +138,11 @@ margin_bottom = 68.0
 rect_min_size = Vector2( 200, 68 )
 mouse_default_cursor_shape = 2
 size_flags_horizontal = 4
+custom_colors/font_color_focus = Color( 0.960784, 0.980392, 0.980392, 1 )
 custom_colors/font_color = Color( 0.572549, 0.560784, 0.721569, 1 )
-custom_colors/font_color_hover = Color( 0.74902, 0.741176, 0.85098, 1 )
+custom_colors/font_color_hover = Color( 0.960784, 0.980392, 0.980392, 1 )
 custom_colors/font_color_pressed = Color( 0.290196, 0.294118, 0.388235, 1 )
-custom_styles/hover = ExtResource( 6 )
+custom_styles/hover = ExtResource( 8 )
 custom_styles/pressed = ExtResource( 3 )
 custom_styles/focus = ExtResource( 8 )
 custom_styles/normal = ExtResource( 4 )

--- a/ui/components/popups/ExternalErrorPopup.tscn
+++ b/ui/components/popups/ExternalErrorPopup.tscn
@@ -1,13 +1,12 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://ui/components/popups/ExternalErrorPopup.gd" type="Script" id=1]
 [ext_resource path="res://ui/theme/fonts/font_title.tres" type="DynamicFont" id=2]
 [ext_resource path="res://ui/theme/button_outline_large_pressed.tres" type="StyleBox" id=3]
 [ext_resource path="res://ui/theme/button_outline_large_normal.tres" type="StyleBox" id=4]
 [ext_resource path="res://ui/theme/panel_normal.tres" type="StyleBox" id=5]
-[ext_resource path="res://ui/theme/button_outline_large_hover.tres" type="StyleBox" id=6]
+[ext_resource path="res://ui/theme/button_outline_large_accented.tres" type="StyleBox" id=6]
 [ext_resource path="res://ui/theme/gdscript_app_theme.tres" type="Theme" id=7]
-[ext_resource path="res://ui/theme/button_outline_large_focus.tres" type="StyleBox" id=8]
 
 [node name="ExternalErrorPopup" type="ColorRect"]
 anchor_right = 1.0
@@ -112,12 +111,14 @@ margin_left = 280.0
 margin_right = 480.0
 margin_bottom = 68.0
 rect_min_size = Vector2( 200, 68 )
+mouse_default_cursor_shape = 2
 size_flags_horizontal = 4
+custom_colors/font_color_focus = Color( 0.239216, 1, 0.431373, 1 )
 custom_colors/font_color = Color( 0.572549, 0.560784, 0.721569, 1 )
-custom_colors/font_color_hover = Color( 0.74902, 0.741176, 0.85098, 1 )
+custom_colors/font_color_hover = Color( 0.239216, 1, 0.431373, 1 )
 custom_colors/font_color_pressed = Color( 0.290196, 0.294118, 0.388235, 1 )
 custom_styles/hover = ExtResource( 6 )
 custom_styles/pressed = ExtResource( 3 )
-custom_styles/focus = ExtResource( 8 )
+custom_styles/focus = ExtResource( 6 )
 custom_styles/normal = ExtResource( 4 )
 text = "Got it!"

--- a/ui/components/popups/LessonDonePopup.tscn
+++ b/ui/components/popups/LessonDonePopup.tscn
@@ -1,10 +1,9 @@
-[gd_scene load_steps=18 format=2]
+[gd_scene load_steps=17 format=2]
 
 [ext_resource path="res://ui/theme/gdscript_app_theme.tres" type="Theme" id=1]
 [ext_resource path="res://ui/components/popups/LessonDonePopup.gd" type="Script" id=2]
 [ext_resource path="res://ui/theme/fonts/font_well_done_title.tres" type="DynamicFont" id=3]
 [ext_resource path="res://ui/theme/fonts/font_well_done_normal.tres" type="DynamicFont" id=4]
-[ext_resource path="res://ui/theme/button_outline_large_hover.tres" type="StyleBox" id=5]
 [ext_resource path="res://ui/theme/button_outline_large_pressed.tres" type="StyleBox" id=6]
 [ext_resource path="res://ui/theme/panel_normal.tres" type="StyleBox" id=7]
 [ext_resource path="res://ui/theme/button_outline_large_normal.tres" type="StyleBox" id=8]
@@ -180,10 +179,11 @@ margin_bottom = 68.0
 rect_min_size = Vector2( 200, 68 )
 mouse_default_cursor_shape = 2
 size_flags_horizontal = 4
+custom_colors/font_color_focus = Color( 0.960784, 0.980392, 0.980392, 1 )
 custom_colors/font_color = Color( 0.572549, 0.560784, 0.721569, 1 )
-custom_colors/font_color_hover = Color( 0.74902, 0.741176, 0.85098, 1 )
+custom_colors/font_color_hover = Color( 0.960784, 0.980392, 0.980392, 1 )
 custom_colors/font_color_pressed = Color( 0.290196, 0.294118, 0.388235, 1 )
-custom_styles/hover = ExtResource( 5 )
+custom_styles/hover = ExtResource( 9 )
 custom_styles/pressed = ExtResource( 6 )
 custom_styles/focus = ExtResource( 9 )
 custom_styles/normal = ExtResource( 8 )
@@ -196,13 +196,14 @@ margin_bottom = 68.0
 rect_min_size = Vector2( 200, 68 )
 mouse_default_cursor_shape = 2
 size_flags_horizontal = 4
-custom_colors/font_color = Color( 0.239216, 1, 0.431373, 1 )
-custom_colors/font_color_hover = Color( 0.74902, 0.741176, 0.85098, 1 )
+custom_colors/font_color_focus = Color( 0.239216, 1, 0.431373, 1 )
+custom_colors/font_color = Color( 0.572549, 0.560784, 0.721569, 1 )
+custom_colors/font_color_hover = Color( 0.239216, 1, 0.431373, 1 )
 custom_colors/font_color_pressed = Color( 0.290196, 0.294118, 0.388235, 1 )
-custom_styles/hover = ExtResource( 5 )
+custom_styles/hover = ExtResource( 13 )
 custom_styles/pressed = ExtResource( 6 )
-custom_styles/focus = ExtResource( 9 )
-custom_styles/normal = ExtResource( 13 )
+custom_styles/focus = ExtResource( 13 )
+custom_styles/normal = ExtResource( 8 )
 text = "Continue"
 
 [node name="Tween" type="Tween" parent="."]

--- a/ui/components/popups/PracticeDonePopup.tscn
+++ b/ui/components/popups/PracticeDonePopup.tscn
@@ -1,10 +1,9 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://ui/theme/gdscript_app_theme.tres" type="Theme" id=1]
 [ext_resource path="res://ui/components/popups/PracticeDonePopup.gd" type="Script" id=2]
 [ext_resource path="res://ui/theme/fonts/font_well_done_title.tres" type="DynamicFont" id=3]
 [ext_resource path="res://ui/theme/fonts/font_well_done_normal.tres" type="DynamicFont" id=4]
-[ext_resource path="res://ui/theme/button_outline_large_hover.tres" type="StyleBox" id=5]
 [ext_resource path="res://ui/theme/button_outline_large_pressed.tres" type="StyleBox" id=6]
 [ext_resource path="res://ui/theme/panel_normal.tres" type="StyleBox" id=7]
 [ext_resource path="res://ui/theme/button_outline_large_normal.tres" type="StyleBox" id=8]
@@ -19,9 +18,6 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 color = Color( 0.0352941, 0.0392157, 0.129412, 0.627451 )
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Layout" type="HBoxContainer" parent="."]
 anchor_left = 0.5
@@ -144,10 +140,11 @@ focus_next = NodePath("../MoveOnButton")
 focus_previous = NodePath(".")
 mouse_default_cursor_shape = 2
 size_flags_horizontal = 4
+custom_colors/font_color_focus = Color( 0.960784, 0.980392, 0.980392, 1 )
 custom_colors/font_color = Color( 0.572549, 0.560784, 0.721569, 1 )
-custom_colors/font_color_hover = Color( 0.74902, 0.741176, 0.85098, 1 )
+custom_colors/font_color_hover = Color( 0.960784, 0.980392, 0.980392, 1 )
 custom_colors/font_color_pressed = Color( 0.290196, 0.294118, 0.388235, 1 )
-custom_styles/hover = ExtResource( 5 )
+custom_styles/hover = ExtResource( 14 )
 custom_styles/pressed = ExtResource( 6 )
 custom_styles/focus = ExtResource( 14 )
 custom_styles/normal = ExtResource( 8 )
@@ -166,13 +163,14 @@ focus_next = NodePath(".")
 focus_previous = NodePath("../StayButton")
 mouse_default_cursor_shape = 2
 size_flags_horizontal = 4
-custom_colors/font_color = Color( 0.239216, 1, 0.431373, 1 )
-custom_colors/font_color_hover = Color( 0.74902, 0.741176, 0.85098, 1 )
+custom_colors/font_color_focus = Color( 0.239216, 1, 0.431373, 1 )
+custom_colors/font_color = Color( 0.572549, 0.560784, 0.721569, 1 )
+custom_colors/font_color_hover = Color( 0.239216, 1, 0.431373, 1 )
 custom_colors/font_color_pressed = Color( 0.290196, 0.294118, 0.388235, 1 )
-custom_styles/hover = ExtResource( 5 )
+custom_styles/hover = ExtResource( 13 )
 custom_styles/pressed = ExtResource( 6 )
-custom_styles/focus = ExtResource( 14 )
-custom_styles/normal = ExtResource( 13 )
+custom_styles/focus = ExtResource( 13 )
+custom_styles/normal = ExtResource( 8 )
 text = "Continue"
 
 [node name="GameAnchors" type="Control" parent="Layout"]

--- a/ui/components/popups/PracticeLeaveUnfinishedPopup.tscn
+++ b/ui/components/popups/PracticeLeaveUnfinishedPopup.tscn
@@ -1,11 +1,10 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://ui/components/popups/PracticeLeaveUnfinishedPopup.gd" type="Script" id=1]
 [ext_resource path="res://ui/theme/fonts/font_title.tres" type="DynamicFont" id=2]
 [ext_resource path="res://ui/theme/button_outline_large_pressed.tres" type="StyleBox" id=3]
 [ext_resource path="res://ui/theme/button_outline_large_normal.tres" type="StyleBox" id=4]
 [ext_resource path="res://ui/theme/panel_normal.tres" type="StyleBox" id=5]
-[ext_resource path="res://ui/theme/button_outline_large_hover.tres" type="StyleBox" id=6]
 [ext_resource path="res://ui/theme/gdscript_app_theme.tres" type="Theme" id=7]
 [ext_resource path="res://ui/theme/button_outline_large_focus.tres" type="StyleBox" id=8]
 [ext_resource path="res://ui/theme/button_outline_large_error.tres" type="StyleBox" id=9]
@@ -113,13 +112,14 @@ margin_bottom = 68.0
 rect_min_size = Vector2( 200, 68 )
 mouse_default_cursor_shape = 2
 size_flags_horizontal = 4
-custom_colors/font_color = Color( 1, 0.0941176, 0.321569, 1 )
-custom_colors/font_color_hover = Color( 0.74902, 0.741176, 0.85098, 1 )
+custom_colors/font_color_focus = Color( 1, 0.0941176, 0.321569, 1 )
+custom_colors/font_color = Color( 0.572549, 0.560784, 0.721569, 1 )
+custom_colors/font_color_hover = Color( 1, 0.0941176, 0.321569, 1 )
 custom_colors/font_color_pressed = Color( 0.290196, 0.294118, 0.388235, 1 )
-custom_styles/hover = ExtResource( 6 )
+custom_styles/hover = ExtResource( 9 )
 custom_styles/pressed = ExtResource( 3 )
-custom_styles/focus = ExtResource( 8 )
-custom_styles/normal = ExtResource( 9 )
+custom_styles/focus = ExtResource( 9 )
+custom_styles/normal = ExtResource( 4 )
 text = "Confirm"
 
 [node name="CancelButton" type="Button" parent="PanelContainer/Column/Margin/Column/Buttons"]
@@ -129,10 +129,11 @@ margin_bottom = 68.0
 rect_min_size = Vector2( 200, 68 )
 mouse_default_cursor_shape = 2
 size_flags_horizontal = 4
+custom_colors/font_color_focus = Color( 0.960784, 0.980392, 0.980392, 1 )
 custom_colors/font_color = Color( 0.572549, 0.560784, 0.721569, 1 )
-custom_colors/font_color_hover = Color( 0.74902, 0.741176, 0.85098, 1 )
+custom_colors/font_color_hover = Color( 0.960784, 0.980392, 0.980392, 1 )
 custom_colors/font_color_pressed = Color( 0.290196, 0.294118, 0.388235, 1 )
-custom_styles/hover = ExtResource( 6 )
+custom_styles/hover = ExtResource( 8 )
 custom_styles/pressed = ExtResource( 3 )
 custom_styles/focus = ExtResource( 8 )
 custom_styles/normal = ExtResource( 4 )

--- a/ui/components/popups/PracticeListPopup.gd
+++ b/ui/components/popups/PracticeListPopup.gd
@@ -11,6 +11,13 @@ func _ready() -> void:
 
 	Events.connect("practice_requested", self, "_on_practice_requested")
 	_cancel_button.connect("pressed", self, "hide")
+	connect("visibility_changed", self, "_on_visibility_changed")
+
+
+
+func _on_visibility_changed() -> void:
+	if visible:
+		_cancel_button.grab_focus()
 
 
 func clear_items() -> void:

--- a/ui/components/popups/PracticeListPopup.tscn
+++ b/ui/components/popups/PracticeListPopup.tscn
@@ -1,23 +1,19 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://ui/components/popups/PracticeListPopup.gd" type="Script" id=1]
 [ext_resource path="res://ui/theme/fonts/font_title.tres" type="DynamicFont" id=2]
 [ext_resource path="res://ui/theme/button_outline_large_pressed.tres" type="StyleBox" id=3]
 [ext_resource path="res://ui/theme/button_outline_large_normal.tres" type="StyleBox" id=4]
 [ext_resource path="res://ui/theme/panel_normal.tres" type="StyleBox" id=5]
-[ext_resource path="res://ui/theme/button_outline_large_hover.tres" type="StyleBox" id=6]
+[ext_resource path="res://ui/theme/button_outline_large_accented.tres" type="StyleBox" id=6]
 [ext_resource path="res://ui/theme/gdscript_app_theme.tres" type="Theme" id=7]
 [ext_resource path="res://addons/SmoothScroll/SmoothScrollContainer.gd" type="Script" id=8]
-[ext_resource path="res://ui/theme/button_outline_large_focus.tres" type="StyleBox" id=9]
 
 [node name="PracticeListPopup" type="ColorRect"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 color = Color( 0.0352941, 0.0392157, 0.129412, 0.627451 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
 anchor_left = 0.5
@@ -110,11 +106,12 @@ margin_bottom = 68.0
 rect_min_size = Vector2( 200, 68 )
 mouse_default_cursor_shape = 2
 size_flags_horizontal = 4
+custom_colors/font_color_focus = Color( 0.239216, 1, 0.431373, 1 )
 custom_colors/font_color = Color( 0.572549, 0.560784, 0.721569, 1 )
-custom_colors/font_color_hover = Color( 0.74902, 0.741176, 0.85098, 1 )
+custom_colors/font_color_hover = Color( 0.239216, 1, 0.431373, 1 )
 custom_colors/font_color_pressed = Color( 0.290196, 0.294118, 0.388235, 1 )
 custom_styles/hover = ExtResource( 6 )
 custom_styles/pressed = ExtResource( 3 )
-custom_styles/focus = ExtResource( 9 )
+custom_styles/focus = ExtResource( 6 )
 custom_styles/normal = ExtResource( 4 )
 text = "Close"

--- a/ui/components/popups/ReportFormPopup.tscn
+++ b/ui/components/popups/ReportFormPopup.tscn
@@ -1,22 +1,18 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://ui/components/popups/ReportFormPopup.gd" type="Script" id=1]
 [ext_resource path="res://ui/theme/fonts/font_title.tres" type="DynamicFont" id=2]
 [ext_resource path="res://ui/theme/button_outline_large_pressed.tres" type="StyleBox" id=3]
 [ext_resource path="res://ui/theme/button_outline_large_normal.tres" type="StyleBox" id=4]
 [ext_resource path="res://ui/theme/panel_normal.tres" type="StyleBox" id=5]
-[ext_resource path="res://ui/theme/button_outline_large_hover.tres" type="StyleBox" id=6]
+[ext_resource path="res://ui/theme/button_outline_large_accented.tres" type="StyleBox" id=6]
 [ext_resource path="res://ui/theme/gdscript_app_theme.tres" type="Theme" id=7]
-[ext_resource path="res://ui/theme/button_outline_large_focus.tres" type="StyleBox" id=8]
 
 [node name="ReportFormPopup" type="ColorRect"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 color = Color( 0.0352941, 0.0392157, 0.129412, 0.627451 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
 anchor_left = 0.5
@@ -151,12 +147,14 @@ margin_top = 616.0
 margin_right = 510.0
 margin_bottom = 684.0
 rect_min_size = Vector2( 200, 68 )
+mouse_default_cursor_shape = 2
 size_flags_horizontal = 4
+custom_colors/font_color_focus = Color( 0.239216, 1, 0.431373, 1 )
 custom_colors/font_color = Color( 0.572549, 0.560784, 0.721569, 1 )
-custom_colors/font_color_hover = Color( 0.74902, 0.741176, 0.85098, 1 )
+custom_colors/font_color_hover = Color( 0.239216, 1, 0.431373, 1 )
 custom_colors/font_color_pressed = Color( 0.290196, 0.294118, 0.388235, 1 )
 custom_styles/hover = ExtResource( 6 )
 custom_styles/pressed = ExtResource( 3 )
-custom_styles/focus = ExtResource( 8 )
+custom_styles/focus = ExtResource( 6 )
 custom_styles/normal = ExtResource( 4 )
 text = "OK"

--- a/ui/components/popups/SettingsPopup.tscn
+++ b/ui/components/popups/SettingsPopup.tscn
@@ -5,7 +5,7 @@
 [ext_resource path="res://ui/theme/button_outline_large_pressed.tres" type="StyleBox" id=3]
 [ext_resource path="res://ui/theme/button_outline_large_normal.tres" type="StyleBox" id=4]
 [ext_resource path="res://ui/theme/panel_normal.tres" type="StyleBox" id=5]
-[ext_resource path="res://ui/theme/button_outline_large_hover.tres" type="StyleBox" id=6]
+[ext_resource path="res://ui/theme/button_outline_large_accented.tres" type="StyleBox" id=6]
 [ext_resource path="res://ui/theme/gdscript_app_theme.tres" type="Theme" id=7]
 [ext_resource path="res://ui/theme/button_outline_large_focus.tres" type="StyleBox" id=8]
 
@@ -215,10 +215,11 @@ margin_bottom = 68.0
 rect_min_size = Vector2( 200, 68 )
 mouse_default_cursor_shape = 2
 size_flags_horizontal = 4
+custom_colors/font_color_focus = Color( 0.960784, 0.980392, 0.980392, 1 )
 custom_colors/font_color = Color( 0.572549, 0.560784, 0.721569, 1 )
-custom_colors/font_color_hover = Color( 0.74902, 0.741176, 0.85098, 1 )
+custom_colors/font_color_hover = Color( 0.960784, 0.980392, 0.980392, 1 )
 custom_colors/font_color_pressed = Color( 0.290196, 0.294118, 0.388235, 1 )
-custom_styles/hover = ExtResource( 6 )
+custom_styles/hover = ExtResource( 8 )
 custom_styles/pressed = ExtResource( 3 )
 custom_styles/focus = ExtResource( 8 )
 custom_styles/normal = ExtResource( 4 )
@@ -231,11 +232,12 @@ margin_bottom = 68.0
 rect_min_size = Vector2( 200, 68 )
 mouse_default_cursor_shape = 2
 size_flags_horizontal = 4
+custom_colors/font_color_focus = Color( 0.239216, 1, 0.431373, 1 )
 custom_colors/font_color = Color( 0.572549, 0.560784, 0.721569, 1 )
-custom_colors/font_color_hover = Color( 0.74902, 0.741176, 0.85098, 1 )
+custom_colors/font_color_hover = Color( 0.239216, 1, 0.431373, 1 )
 custom_colors/font_color_pressed = Color( 0.290196, 0.294118, 0.388235, 1 )
 custom_styles/hover = ExtResource( 6 )
 custom_styles/pressed = ExtResource( 3 )
-custom_styles/focus = ExtResource( 8 )
+custom_styles/focus = ExtResource( 6 )
 custom_styles/normal = ExtResource( 4 )
 text = "Apply"

--- a/ui/screens/course_outliner/CourseLessonDetails.tscn
+++ b/ui/screens/course_outliner/CourseLessonDetails.tscn
@@ -14,9 +14,6 @@ rect_min_size = Vector2( 420, 0 )
 theme = ExtResource( 4 )
 custom_styles/panel = ExtResource( 6 )
 script = ExtResource( 5 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 margin_left = 8.0

--- a/ui/screens/course_outliner/CourseLessonList.tscn
+++ b/ui/screens/course_outliner/CourseLessonList.tscn
@@ -12,9 +12,6 @@ rect_min_size = Vector2( 640, 0 )
 theme = ExtResource( 2 )
 custom_styles/panel = ExtResource( 1 )
 script = ExtResource( 3 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="ScrollContainer" type="ScrollContainer" parent="."]
 margin_left = 8.0

--- a/ui/screens/lesson/UIPracticeButton.tscn
+++ b/ui/screens/lesson/UIPracticeButton.tscn
@@ -29,9 +29,6 @@ anchor_right = 1.0
 margin_bottom = 110.0
 custom_styles/panel = ExtResource( 3 )
 script = ExtResource( 5 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Margin" type="MarginContainer" parent="."]
 margin_right = 1920.0
@@ -107,8 +104,13 @@ rect_min_size = Vector2( 180, 60 )
 hint_tooltip = "Open this practice."
 mouse_default_cursor_shape = 2
 size_flags_vertical = 4
+custom_colors/font_color_focus = Color( 0.960784, 0.980392, 0.980392, 1 )
+custom_colors/font_color = Color( 0.572549, 0.560784, 0.721569, 1 )
+custom_colors/font_color_hover = Color( 0.960784, 0.980392, 0.980392, 1 )
+custom_colors/font_color_pressed = Color( 0.290196, 0.294118, 0.388235, 1 )
 custom_styles/hover = ExtResource( 7 )
 custom_styles/pressed = ExtResource( 8 )
+custom_styles/focus = ExtResource( 7 )
 custom_styles/normal = ExtResource( 9 )
 text = "Practice"
 

--- a/ui/screens/welcome_screen/WelcomeScreen.tscn
+++ b/ui/screens/welcome_screen/WelcomeScreen.tscn
@@ -23,8 +23,7 @@ rect_pivot_offset = Vector2( 2495, 16 )
 theme = ExtResource( 2 )
 script = ExtResource( 8 )
 __meta__ = {
-"_edit_horizontal_guides_": [ 1060.0 ],
-"_edit_use_anchors_": false
+"_edit_horizontal_guides_": [ 1060.0 ]
 }
 
 [node name="Layout" type="VBoxContainer" parent="."]

--- a/ui/theme/button_outlined_accent_hover.tres
+++ b/ui/theme/button_outlined_accent_hover.tres
@@ -11,7 +11,6 @@ border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
 border_color = Color( 0.960784, 0.980392, 0.980392, 1 )
-border_blend = true
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8

--- a/ui/theme/button_outlined_accent_normal.tres
+++ b/ui/theme/button_outlined_accent_normal.tres
@@ -11,7 +11,6 @@ border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
 border_color = Color( 0.14902, 0.776471, 0.968627, 1 )
-border_blend = true
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8

--- a/ui/theme/button_outlined_accent_pressed.tres
+++ b/ui/theme/button_outlined_accent_pressed.tres
@@ -11,7 +11,6 @@ border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
 border_color = Color( 0.117647, 0.521569, 0.878431, 1 )
-border_blend = true
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8

--- a/ui/theme/button_outlined_hover.tres
+++ b/ui/theme/button_outlined_hover.tres
@@ -11,7 +11,6 @@ border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
 border_color = Color( 0.960784, 0.980392, 0.980392, 1 )
-border_blend = true
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8

--- a/ui/theme/button_outlined_normal.tres
+++ b/ui/theme/button_outlined_normal.tres
@@ -11,7 +11,6 @@ border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
 border_color = Color( 0.572549, 0.560784, 0.721569, 1 )
-border_blend = true
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8

--- a/ui/theme/button_outlined_pressed.tres
+++ b/ui/theme/button_outlined_pressed.tres
@@ -11,7 +11,6 @@ border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
 border_color = Color( 0.14902, 0.776471, 0.968627, 1 )
-border_blend = true
 corner_radius_top_left = 8
 corner_radius_top_right = 8
 corner_radius_bottom_right = 8


### PR DESCRIPTION
Changed a range of button themes for the ones that have borders. There are two states for:

- focus & hover: white color unless they're in a popup with green/red top-bar in which case the color is the same as the top bar for the cancel/confirm buttons depending on the case.
- normal: gray-blue color for all.

Pressed state is unchanged.

I also changed:

- how the `Start/Continue Course` looks on focus & hover to be consistent with the pop-ups.
- remove border blending on all button styles for consistency.
- add a `grab_focus()` on the cancel button for `/ui/components/popups/PracticeListPopup.gd` to be the same as the rest.

closes #346