### PR TITLE
fix(lessons 17 18): constrain robot to board

### DIFF
--- a/course/lesson-17-while-loops/visuals/ExampleBoardWhile.tscn
+++ b/course/lesson-17-while-loops/visuals/ExampleBoardWhile.tscn
@@ -20,6 +20,10 @@ func _set_instance_value(value: float, property_name: String, value_label: Label
 script/source = "extends \"Board.gd\"
 
 
+func _ready() -> void:
+	_robot.connect(\"cell_changed\", self, \"_update_label\")
+
+
 func run() -> void:
 	reset()
 	_timer.start(0.5)
@@ -28,7 +32,8 @@ func run() -> void:
 func reset() -> void:
 	_timer.stop()
 	_robot.cell = Vector2(0, 1)
-	_update_label()
+#	_update_label()
+
 
 func _update_label() -> void:
 	_label.text = \"cell = Vector2\" + str(_robot.cell)
@@ -39,7 +44,7 @@ func _on_timer_timeout() -> void:
 		_timer.stop()
 		return
 	_robot.cell += Vector2(1, 0)
-	_update_label()
+#	_update_label()
 "
 
 [node name="ExampleGrid" type="PanelContainer"]

--- a/course/lesson-17-while-loops/visuals/ExampleRobotMoveRight.tscn
+++ b/course/lesson-17-while-loops/visuals/ExampleRobotMoveRight.tscn
@@ -22,12 +22,14 @@ func reset() -> void:
 	_robot.cell = Vector2(0, 1)
 	_update_label()
 
+
 func _on_timer_timeout() -> void:
 	if _robot.cell.x > 1:
 		_timer.stop()
 		return
 	_robot.cell += Vector2(1, 0)
 	_update_label()
+
 
 func _update_label() -> void:
 	_label.text = \"cell = Vector2\" + str(_robot.cell)
@@ -37,9 +39,6 @@ func _update_label() -> void:
 margin_right = 658.0
 margin_bottom = 384.0
 size_flags_horizontal = 3
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="RunnableCodeExample" parent="." instance=ExtResource( 1 )]
 margin_left = 7.0

--- a/course/lesson-17-while-loops/visuals/Robot.gd
+++ b/course/lesson-17-while-loops/visuals/Robot.gd
@@ -1,6 +1,8 @@
 extends Node2D
 
 
+signal cell_changed
+
 var cell := Vector2(0, 0) setget set_cell, get_cell
 var cell_size := 96
 var grid_size_px := Vector2.ZERO setget set_grid_size_px
@@ -8,11 +10,14 @@ var grid_size_px := Vector2.ZERO setget set_grid_size_px
 
 func set_cell(new_cell: Vector2) -> void:
 	cell = new_cell
-	position = new_cell * cell_size + Vector2(cell_size/2, 12) - grid_size_px / 2.0
+	cell.x = min(cell.x, grid_size_px.x / cell_size - 1)
+	position = cell * cell_size + Vector2(cell_size/2, 12) - grid_size_px / 2.0
+	emit_signal("cell_changed")
 
 
 func get_cell() -> Vector2:
 	return cell
+
 
 func set_grid_size_px(value: Vector2):
 	grid_size_px = value

--- a/course/lesson-18-for-loops/visuals/ExampleBoardFor.tscn
+++ b/course/lesson-18-for-loops/visuals/ExampleBoardFor.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource path="res://course/common/Robot.tscn" type="PackedScene" id=1]
 [ext_resource path="res://ui/components/RunnableCodeExample.tscn" type="PackedScene" id=2]
+[ext_resource path="res://course/lesson-17-while-loops/visuals/Robot.gd" type="Script" id=3]
 
 [sub_resource type="GDScript" id=1]
 script/source = "tool
@@ -22,6 +23,10 @@ var _board_width := 0
 var _loops := 0
 
 
+func _ready() -> void:
+	_robot.connect(\"cell_changed\", self, \"_update_label\")
+
+
 func _update_label() -> void:
 	if not _label:
 		yield(self, \"ready\")
@@ -39,7 +44,6 @@ func reset() -> void:
 	_loops = 0
 	_timer.stop()
 	_robot.cell = Vector2(0, 1)
-	_update_label()
 
 
 func _on_timer_timeout() -> void:
@@ -50,29 +54,6 @@ func _on_timer_timeout() -> void:
 		return
 	
 	_robot.cell += Vector2(1, 0)
-	_update_label()
-"
-
-[sub_resource type="GDScript" id=3]
-script/source = "extends Node2D
-
-
-var cell := Vector2(0, 0) setget set_cell, get_cell
-var cell_size := 96
-var grid_size_px := Vector2.ZERO setget set_grid_size_px
-
-
-func set_cell(new_cell: Vector2) -> void:
-	cell = new_cell
-	position = new_cell * cell_size + Vector2(cell_size/2, 12) - grid_size_px / 2.0
-
-
-func get_cell() -> Vector2:
-	return cell
-
-func set_grid_size_px(value: Vector2):
-	grid_size_px = value
-	set_cell(cell)
 "
 
 [node name="ExampleBoardFor" type="PanelContainer"]
@@ -97,7 +78,7 @@ position = Vector2( 50, 100 )
 script = SubResource( 2 )
 
 [node name="Robot" parent="RunnableCodeExample/BoardForLoop" instance=ExtResource( 1 )]
-script = SubResource( 3 )
+script = ExtResource( 3 )
 
 [node name="Label" type="Label" parent="RunnableCodeExample/BoardForLoop"]
 margin_left = 48.0


### PR DESCRIPTION
When changing board size after the robot moves, make the character
stay inside the board.

fixes #371
