### PR TITLE
chore: add version info for desktop platforms

### DIFF
--- a/run
+++ b/run
@@ -190,6 +190,7 @@ export_custom(){
   output=$2
   dir=$(dirname "$output")
   mkdir -p "$dir"
+  prepare_versionfile
   if [ -z "$debug" ]; then
     echo "godot --quiet --no-window --export \"$export_name\" \"$output\""
     test "$dry" || godot --quiet --no-window --export "$export_name" "$output"

--- a/run
+++ b/run
@@ -461,7 +461,7 @@ prepare_htmltemplate(){
     echo "cannot run in dry mode"
     exit 0
   fi
-  sed "s@>branch and commit hash@>${watermark}<@" html_export/index_template.html > html_export/index.html
+  sed "s@>branch and commit hash<@>${watermark}<@" html_export/index_template.html > html_export/index.html
   sed -i "s@GDQUEST_ENVIRONMENT = {}@GDQUEST_ENVIRONMENT = {\n \
      build_date: \"$build_date\",\n \
      build_date_iso: \"$build_date_iso\",\n \
@@ -523,6 +523,9 @@ _prepare_build_vars(){
     version=$(git describe --tags --abbrev=0 --match "*.*.*")
   fi
   watermark="$build_date_iso | $git_branch:$version:$git_commit"
+  if [ "$should_use_branch" = false ]; then
+    watermark="version: $version"
+  fi
   if [ -z "$url" ]; then
     url=${1:-"https://gdquest.github.io/learn-gdscript"}
     if [ "$should_use_branch" = true ]; then

--- a/ui/UICore.tscn
+++ b/ui/UICore.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://ui/screens/welcome_screen/WelcomeScreen.tscn" type="PackedScene" id=1]
 [ext_resource path="res://ui/theme/gdscript_app_theme.tres" type="Theme" id=2]
@@ -7,6 +7,8 @@
 [ext_resource path="res://ui/components/popups/ReportFormPopup.tscn" type="PackedScene" id=5]
 [ext_resource path="res://ui/components/popups/SettingsPopup.tscn" type="PackedScene" id=6]
 [ext_resource path="res://ui/screens/end_screen/EndScreen.tscn" type="PackedScene" id=7]
+[ext_resource path="res://ui/UIVersion.gd" type="Script" id=8]
+[ext_resource path="res://ui/theme/fonts/font_version.tres" type="DynamicFont" id=9]
 
 [node name="UICore" type="Control"]
 pause_mode = 2
@@ -51,3 +53,28 @@ mouse_filter = 2
 [node name="SettingsPopup" parent="." instance=ExtResource( 6 )]
 visible = false
 mouse_filter = 2
+
+[node name="UIVersion" type="Control" parent="."]
+visible = false
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 0
+grow_vertical = 0
+mouse_filter = 2
+script = ExtResource( 8 )
+
+[node name="RichTextLabel" type="RichTextLabel" parent="UIVersion"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_top = -20.0
+margin_right = -2.0
+grow_vertical = 0
+rect_min_size = Vector2( 1918, 20 )
+focus_mode = 2
+custom_colors/default_color = Color( 0.572549, 0.560784, 0.721569, 1 )
+custom_fonts/normal_font = ExtResource( 9 )
+bbcode_enabled = true
+meta_underlined = false
+scroll_active = false
+selection_enabled = true

--- a/ui/UIVersion.gd
+++ b/ui/UIVersion.gd
@@ -1,0 +1,40 @@
+extends Control
+
+
+onready var _rich_text_label := $RichTextLabel
+
+
+func _ready() -> void:
+	visible = not OS.has_feature("web")
+
+	_rich_text_label.connect("meta_clicked", OS, "shell_open")
+	_rich_text_label.connect("meta_hover_started", self, "_on_meta_hover_started")
+	_rich_text_label.connect("meta_hover_ended", self, "_on_meta_hover_ended")
+
+	var text := PoolStringArray([
+		"[right]",
+		"%04d/%02d/%02d %02d:%02d:%02d" % AppVersion.build_date,
+		" | ",
+		"%s:%s:" % [AppVersion.git_branch, AppVersion.version],
+		"[url=https://github.com/GDQuest/learn-gdscript/tree/{0}]{0}[/url]".format([AppVersion.git_commit]),
+		"[/right]"
+	]).join("")
+
+	if AppVersion.git_branch == "release":
+		text = PoolStringArray([
+			"[right]",
+			"[url=https://github.com/GDQuest/learn-gdscript/blob/main/CHANGELOG.md]",
+			"version: %s" % AppVersion.version,
+			"[/url]",
+			"[/right]"
+		]).join("")
+
+	_rich_text_label.bbcode_text = text
+
+
+func _on_meta_hover_started(_meta: String) -> void:
+	_rich_text_label.mouse_default_cursor_shape = CURSOR_POINTING_HAND
+
+
+func _on_meta_hover_ended(_meta: String) -> void:
+	_rich_text_label.mouse_default_cursor_shape = CURSOR_ARROW

--- a/ui/theme/fonts/font_version.tres
+++ b/ui/theme/fonts/font_version.tres
@@ -1,0 +1,7 @@
+[gd_resource type="DynamicFont" load_steps=2 format=2]
+
+[ext_resource path="res://ui/theme/fonts/OpenSans-Regular.ttf" type="DynamicFontData" id=1]
+
+[resource]
+size = 14
+font_data = ExtResource( 1 )

--- a/utils/version.gd
+++ b/utils/version.gd
@@ -1,9 +1,9 @@
-# AUTO GENERATED FILE, YOUR CHANGES WILL NOT REMAIN
+# AUTO GENERATED changed_file, YOUR CHANGES WILL NOT REMAIN
 class_name AppVersion
 
 const version := "0.3.0";
-const git_commit := "e5d041daa4fa7eaa6932d1ae02fdb97782678eeb";
-const git_branch := "main";
-const build_date := [2022, 02, 14, 18, 45, 09];
-const build_date_unix := 1644849909;
-const build_date_iso := "2022/02/14 18:45:09;"
+const git_commit := "6de164cb076cb7ae64eabd4e9e28fdcc865e3840";
+const git_branch := "version-number";
+const build_date := [2022, 03, 02, 14, 11, 31];
+const build_date_unix := 1646223091;
+const build_date_iso := "2022/03/02 14:11:31;"


### PR DESCRIPTION
It also handles mouse clicks:

- hash goes to github hash version
- version number goes to the changelog file

closes #375
closes #376
