### PR TITLE
fix: prefer fuzzy font on scale rather than pixelated

### DIFF
--- a/ui/theme/fonts/font_button.tres
+++ b/ui/theme/fonts/font_button.tres
@@ -4,4 +4,6 @@
 
 [resource]
 size = 24
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_button_big_green.tres
+++ b/ui/theme/fonts/font_button_big_green.tres
@@ -4,5 +4,7 @@
 
 [resource]
 size = 24
+use_mipmaps = true
+use_filter = true
 extra_spacing_char = 1
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_button_small.tres
+++ b/ui/theme/fonts/font_button_small.tres
@@ -5,4 +5,6 @@ font_path = "res://ui/theme/fonts/Montserrat-Bold.ttf"
 
 [resource]
 size = 18
+use_mipmaps = true
+use_filter = true
 font_data = SubResource( 1 )

--- a/ui/theme/fonts/font_code.tres
+++ b/ui/theme/fonts/font_code.tres
@@ -4,4 +4,6 @@
 
 [resource]
 size = 20
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_code_small.tres
+++ b/ui/theme/fonts/font_code_small.tres
@@ -3,4 +3,6 @@
 [ext_resource path="res://ui/theme/fonts/SourceCodePro-Regular.otf" type="DynamicFontData" id=1]
 
 [resource]
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_documentation_bold.tres
+++ b/ui/theme/fonts/font_documentation_bold.tres
@@ -4,4 +4,6 @@
 
 [resource]
 size = 18
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_documentation_italics.tres
+++ b/ui/theme/fonts/font_documentation_italics.tres
@@ -4,4 +4,6 @@
 
 [resource]
 size = 18
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_documentation_mono.tres
+++ b/ui/theme/fonts/font_documentation_mono.tres
@@ -4,4 +4,6 @@
 
 [resource]
 size = 18
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_documentation_normal.tres
+++ b/ui/theme/fonts/font_documentation_normal.tres
@@ -4,4 +4,6 @@
 
 [resource]
 size = 18
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_lesson_heading.tres
+++ b/ui/theme/fonts/font_lesson_heading.tres
@@ -4,5 +4,7 @@
 
 [resource]
 size = 28
+use_mipmaps = true
+use_filter = true
 extra_spacing_top = 8
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_percent.tres
+++ b/ui/theme/fonts/font_percent.tres
@@ -6,6 +6,8 @@
 size = 18
 outline_size = 2
 outline_color = Color( 0.290196, 0.294118, 0.388235, 1 )
+use_mipmaps = true
+use_filter = true
 extra_spacing_top = 2
 extra_spacing_bottom = 2
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_practice_progress.tres
+++ b/ui/theme/fonts/font_practice_progress.tres
@@ -4,4 +4,6 @@
 
 [resource]
 size = 22
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_text.tres
+++ b/ui/theme/fonts/font_text.tres
@@ -4,4 +4,6 @@
 
 [resource]
 size = 20
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_text_bold.tres
+++ b/ui/theme/fonts/font_text_bold.tres
@@ -4,4 +4,6 @@
 
 [resource]
 size = 20
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_text_bold_italics.tres
+++ b/ui/theme/fonts/font_text_bold_italics.tres
@@ -4,4 +4,6 @@
 
 [resource]
 size = 20
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_text_italics.tres
+++ b/ui/theme/fonts/font_text_italics.tres
@@ -4,4 +4,6 @@
 
 [resource]
 size = 20
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_title.tres
+++ b/ui/theme/fonts/font_title.tres
@@ -4,4 +4,6 @@
 
 [resource]
 size = 24
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_title_big.tres
+++ b/ui/theme/fonts/font_title_big.tres
@@ -4,4 +4,6 @@
 
 [resource]
 size = 32
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_title_slim.tres
+++ b/ui/theme/fonts/font_title_slim.tres
@@ -4,4 +4,6 @@
 
 [resource]
 size = 24
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_title_small.tres
+++ b/ui/theme/fonts/font_title_small.tres
@@ -5,4 +5,6 @@ font_path = "res://ui/theme/fonts/Montserrat-Bold.ttf"
 
 [resource]
 size = 20
+use_mipmaps = true
+use_filter = true
 font_data = SubResource( 1 )

--- a/ui/theme/fonts/font_version.tres
+++ b/ui/theme/fonts/font_version.tres
@@ -4,4 +4,6 @@
 
 [resource]
 size = 14
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_well_done_bold.tres
+++ b/ui/theme/fonts/font_well_done_bold.tres
@@ -4,4 +4,6 @@
 
 [resource]
 size = 26
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_well_done_normal.tres
+++ b/ui/theme/fonts/font_well_done_normal.tres
@@ -4,4 +4,6 @@
 
 [resource]
 size = 26
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )

--- a/ui/theme/fonts/font_well_done_title.tres
+++ b/ui/theme/fonts/font_well_done_title.tres
@@ -4,4 +4,6 @@
 
 [resource]
 size = 42
+use_mipmaps = true
+use_filter = true
 font_data = ExtResource( 1 )


### PR DESCRIPTION
I turned on `Use Mipmaps` and `Use Filter` on all fonts and it does improve a little bit although there still are corner cases. I think overall it's better than having it pixelated though it introduces a bit of fuzziness.

This is how first L23 exercise looks in the browser scaled by the view of the browser window (so it isn't fullscreen)
![image](https://user-images.githubusercontent.com/1177508/156767056-82f92f28-2bd0-47cb-bb3e-a39c36eb45d7.png)

Compared to fullscreen:
![image](https://user-images.githubusercontent.com/1177508/156767591-40b7e904-eb5a-44f0-b85a-d8afb438586a.png)

I opened the PR to have a discussion if it's necessary to change the font specifically for some examples as well.
