### PR TITLE
improve: start in fullscreen mode by default

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -397,6 +397,7 @@ gdscript/warnings/unsafe_call_argument=true
 
 window/size/width=1920
 window/size/height=1080
+window/size/fullscreen=true
 window/size/test_width=1080
 window/size/test_height=600
 window/dpi/allow_hidpi=true

--- a/ui/UINavigator.tscn
+++ b/ui/UINavigator.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=2]
+[gd_scene load_steps=14 format=2]
 
 [ext_resource path="res://ui/theme/gdscript_app_theme.tres" type="Theme" id=1]
 [ext_resource path="res://ui/components/BreadCrumbs.tscn" type="PackedScene" id=2]
@@ -12,6 +12,7 @@
 [ext_resource path="res://ui/icons/icon_godot_head.svg" type="Texture" id=10]
 [ext_resource path="res://ui/components/FullScreenButton.tscn" type="PackedScene" id=11]
 [ext_resource path="res://ui/components/popups/LessonDonePopup.tscn" type="PackedScene" id=12]
+[ext_resource path="res://ui/components/QuitButton.tscn" type="PackedScene" id=13]
 
 [node name="UINavigator" type="PanelContainer"]
 anchor_right = 1.0
@@ -19,9 +20,6 @@ anchor_bottom = 1.0
 mouse_filter = 2
 theme = ExtResource( 1 )
 script = ExtResource( 4 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Layout" type="VBoxContainer" parent="."]
 margin_right = 1920.0
@@ -84,14 +82,14 @@ margin_right = 96.0
 
 [node name="Spacer" type="Control" parent="Layout/Header/MarginContainer/HeaderContent"]
 margin_left = 112.0
-margin_right = 1712.0
+margin_right = 1656.0
 margin_bottom = 48.0
 rect_pivot_offset = Vector2( -514, 99 )
 size_flags_horizontal = 3
 
 [node name="ReportButton" type="Button" parent="Layout/Header/MarginContainer/HeaderContent"]
-margin_left = 1728.0
-margin_right = 1776.0
+margin_left = 1672.0
+margin_right = 1720.0
 margin_bottom = 48.0
 hint_tooltip = "Report an issue"
 mouse_default_cursor_shape = 2
@@ -99,8 +97,8 @@ icon = ExtResource( 6 )
 flat = true
 
 [node name="SettingsButton" type="Button" parent="Layout/Header/MarginContainer/HeaderContent"]
-margin_left = 1792.0
-margin_right = 1840.0
+margin_left = 1736.0
+margin_right = 1784.0
 margin_bottom = 48.0
 hint_tooltip = "Configure the app"
 mouse_default_cursor_shape = 2
@@ -108,11 +106,14 @@ icon = ExtResource( 5 )
 flat = true
 
 [node name="FullScreenButton" parent="Layout/Header/MarginContainer/HeaderContent" instance=ExtResource( 11 )]
+margin_left = 1800.0
+margin_right = 1840.0
+margin_bottom = 47.0
+
+[node name="QuitButton" parent="Layout/Header/MarginContainer/HeaderContent" instance=ExtResource( 13 )]
 margin_left = 1856.0
 margin_right = 1896.0
-margin_bottom = 48.0
-mouse_default_cursor_shape = 2
-size_flags_vertical = 1
+margin_bottom = 47.0
 
 [node name="Content" type="Panel" parent="Layout"]
 margin_top = 48.0

--- a/ui/components/FullScreenButton.gd
+++ b/ui/components/FullScreenButton.gd
@@ -14,6 +14,7 @@ func _ready() -> void:
 		return
 	connect("pressed", self, "_on_pressed")
 	Events.connect("fullscreen_toggled", self, "_update_icon")
+	_update_icon()
 
 
 func _on_pressed() -> void:

--- a/ui/components/FullScreenButton.tscn
+++ b/ui/components/FullScreenButton.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://ui/icons/fullscreen_on.png" type="Texture" id=1]
 [ext_resource path="res://ui/components/FullScreenButton.gd" type="Script" id=2]
-[ext_resource path="res://ui/theme/fonts/font_button_small.tres" type="DynamicFont" id=3]
 
 [node name="FullScreenButton" type="Button"]
 margin_right = 36.0
@@ -10,12 +9,9 @@ margin_bottom = 30.0
 rect_min_size = Vector2( 24, 24 )
 hint_tooltip = "Toggle the app full-screen.
 Shortcut: F11"
+mouse_default_cursor_shape = 2
 size_flags_vertical = 4
-custom_fonts/font = ExtResource( 3 )
 shortcut_in_tooltip = false
 icon = ExtResource( 1 )
 flat = true
 script = ExtResource( 2 )
-__meta__ = {
-"_edit_use_anchors_": false
-}

--- a/ui/components/QuitButton.gd
+++ b/ui/components/QuitButton.gd
@@ -1,0 +1,8 @@
+extends Button
+
+
+func _ready() -> void:
+	connect("pressed", get_tree(), "quit")
+	
+	if OS.has_feature("JavaScript"):
+		queue_free()

--- a/ui/components/QuitButton.tscn
+++ b/ui/components/QuitButton.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://ui/icons/quit.svg" type="Texture" id=1]
+[ext_resource path="res://ui/components/QuitButton.gd" type="Script" id=2]
+
+[node name="QuitButton" type="Button"]
+margin_right = 36.0
+margin_bottom = 30.0
+hint_tooltip = "Quit the app.
+Shortcut: Alt+F4"
+mouse_default_cursor_shape = 2
+size_flags_horizontal = 0
+size_flags_vertical = 0
+icon = ExtResource( 1 )
+flat = true
+script = ExtResource( 2 )

--- a/ui/icons/quit.svg
+++ b/ui/icons/quit.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg5"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <g
+     id="layer1"
+     transform="translate(-4.2762303,-4.2762304)">
+    <g
+       id="g1421"
+       transform="matrix(1.0345925,0,0,1.0345925,0.03754281,-0.4079828)"
+       style="fill:#faffff">
+      <rect
+         style="fill:#faffff;stroke:none;stroke-width:0.665001"
+         id="rect1237"
+         width="5.7711167"
+         height="27.035156"
+         x="-3.1900592"
+         y="8.9840403"
+         transform="rotate(-45)" />
+      <rect
+         style="fill:#faffff;stroke:none;stroke-width:0.665001"
+         id="rect1417"
+         width="5.7711167"
+         height="27.035156"
+         x="-25.387178"
+         y="-13.822079"
+         transform="rotate(-135)" />
+    </g>
+  </g>
+</svg>

--- a/ui/icons/quit.svg.import
+++ b/ui/icons/quit.svg.import
@@ -1,0 +1,35 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/quit.svg-e1a25ca2facf33e0c7b8ef00741d0999.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://ui/icons/quit.svg"
+dest_files=[ "res://.import/quit.svg-e1a25ca2facf33e0c7b8ef00741d0999.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+process/normal_map_invert_y=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0

--- a/ui/screens/end_screen/EndScreen.gd
+++ b/ui/screens/end_screen/EndScreen.gd
@@ -1,5 +1,6 @@
 extends Control
 
+
 onready var _content_container := $Layout/MarginContainer/ColumnLayout/MainColumn/MainContent/MarginContainer/ScrollContainer/VBoxContainer
 onready var _outliner_button := $Layout/TopBar/MarginContainer/ToolBarLayout/OutlinerButton as Button
 

--- a/ui/screens/end_screen/EndScreen.tscn
+++ b/ui/screens/end_screen/EndScreen.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://ui/components/GDQuestLogo.tscn" type="PackedScene" id=1]
 [ext_resource path="res://ui/theme/gdscript_app_theme.tres" type="Theme" id=2]
 [ext_resource path="res://ui/theme/panel_normal.tres" type="StyleBox" id=3]
 [ext_resource path="res://ui/theme/fonts/font_title_big.tres" type="DynamicFont" id=4]
+[ext_resource path="res://ui/components/QuitButton.tscn" type="PackedScene" id=5]
 [ext_resource path="res://ui/screens/end_screen/EndScreen.gd" type="Script" id=6]
 [ext_resource path="res://ui/components/FullScreenButton.tscn" type="PackedScene" id=7]
 [ext_resource path="res://ui/theme/panel_breadcrumbs.tres" type="StyleBox" id=8]
@@ -17,9 +18,6 @@ anchor_bottom = 1.0
 rect_pivot_offset = Vector2( 2495, 16 )
 theme = ExtResource( 2 )
 script = ExtResource( 6 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Layout" type="VBoxContainer" parent="."]
 anchor_right = 1.0
@@ -59,15 +57,19 @@ flat = true
 
 [node name="Control" type="Control" parent="Layout/TopBar/MarginContainer/ToolBarLayout"]
 margin_left = 48.0
-margin_right = 1840.0
+margin_right = 1784.0
 margin_bottom = 47.0
 size_flags_horizontal = 3
 
 [node name="FullScreenButton" parent="Layout/TopBar/MarginContainer/ToolBarLayout" instance=ExtResource( 7 )]
+margin_left = 1800.0
+margin_right = 1840.0
+margin_bottom = 47.0
+
+[node name="QuitButton" parent="Layout/TopBar/MarginContainer/ToolBarLayout" instance=ExtResource( 5 )]
 margin_left = 1856.0
-margin_top = 3.0
 margin_right = 1896.0
-margin_bottom = 43.0
+margin_bottom = 47.0
 
 [node name="MarginContainer" type="MarginContainer" parent="Layout"]
 margin_left = 512.0

--- a/ui/screens/welcome_screen/WelcomeScreen.gd
+++ b/ui/screens/welcome_screen/WelcomeScreen.gd
@@ -5,6 +5,7 @@ signal course_requested(force_outliner)
 onready var _settings_button := $Layout/MarginContainer/ColumnLayout/SideColumn/SettingsButton as Button
 onready var _outliner_button := $Layout/MarginContainer/ColumnLayout/SideColumn/OutlinerButton as Button
 onready var _start_button := $Layout/MarginContainer/ColumnLayout/SideColumn/StartButton as Button
+onready var _quit_button := $Layout/MarginContainer/ColumnLayout/SideColumn/QuitButton as Button
 onready var _report_button := $Layout/TopBar/MarginContainer/ToolBarLayout/ReportButton as Button
 onready var _scroll_container := $Layout/MarginContainer/ColumnLayout/MainColumn/MainContent/MarginContainer/ScrollContainer as ScrollContainer
 
@@ -18,6 +19,7 @@ func _ready() -> void:
 	_settings_button.connect("pressed", Events, "emit_signal", ["settings_requested"])
 	_outliner_button.connect("pressed", self, "_on_outliner_pressed")
 	_start_button.connect("pressed", self, "_on_start_requested")
+	_quit_button.connect("pressed", get_tree(), "quit")
 	
 	_report_button.connect("pressed", Events, "emit_signal", ["report_form_requested"])
 	for child in _content_list.get_children():
@@ -25,6 +27,9 @@ func _ready() -> void:
 			child.connect("meta_clicked", OS, "shell_open")
 
 	_scroll_container.grab_focus()
+	
+	if OS.has_feature('JavaScript'):
+		_quit_button.queue_free()
 
 
 func set_button_continue(enable: bool = true) -> void:

--- a/ui/screens/welcome_screen/WelcomeScreen.tscn
+++ b/ui/screens/welcome_screen/WelcomeScreen.tscn
@@ -61,10 +61,8 @@ icon = ExtResource( 6 )
 
 [node name="FullScreenButton" parent="Layout/TopBar/MarginContainer/ToolBarLayout" instance=ExtResource( 11 )]
 margin_left = 1856.0
-margin_top = 4.0
 margin_right = 1896.0
-margin_bottom = 44.0
-mouse_default_cursor_shape = 2
+margin_bottom = 47.0
 
 [node name="MarginContainer" type="MarginContainer" parent="Layout"]
 margin_left = 310.0
@@ -369,26 +367,35 @@ __meta__ = {
 [node name="Spacer" type="Control" parent="Layout/MarginContainer/ColumnLayout/SideColumn"]
 margin_top = 555.0
 margin_right = 356.0
-margin_bottom = 754.0
+margin_bottom = 691.0
 size_flags_vertical = 3
 
 [node name="SettingsButton" type="Button" parent="Layout/MarginContainer/ColumnLayout/SideColumn"]
-margin_top = 770.0
+margin_top = 707.0
 margin_right = 356.0
-margin_bottom = 817.0
+margin_bottom = 754.0
 mouse_default_cursor_shape = 2
 text = "Configure the App"
 
 [node name="OutlinerButton" type="Button" parent="Layout/MarginContainer/ColumnLayout/SideColumn"]
-margin_top = 833.0
+margin_top = 770.0
 margin_right = 356.0
-margin_bottom = 880.0
+margin_bottom = 817.0
 mouse_default_cursor_shape = 2
 text = "Open Course Index"
 
 [node name="StartButton" parent="Layout/MarginContainer/ColumnLayout/SideColumn" instance=ExtResource( 9 )]
+margin_top = 833.0
+margin_bottom = 913.0
 custom_colors/font_color_hover = Color( 0.960784, 0.980392, 0.980392, 1 )
 text = "Start Course"
+
+[node name="QuitButton" type="Button" parent="Layout/MarginContainer/ColumnLayout/SideColumn"]
+margin_top = 929.0
+margin_right = 356.0
+margin_bottom = 976.0
+mouse_default_cursor_shape = 2
+text = "Quit"
 
 [node name="GDQuestLogo" parent="." instance=ExtResource( 15 )]
 modulate = Color( 0.572549, 0.560784, 0.721569, 1 )


### PR DESCRIPTION
Reason I made this a draft is to confirm if the state should be saved and restored without user input. The state being: window size, window position and window fullscreen state. The current behavior is to save these to the user profile and restore it on subsequent runs.

If this is fine, only thing I'd do is add a reset button to the Settings panel to reset the state to the project default settings, in case someone wants to recenter the window or what-not.

closes #400 