### PR TITLE
improvement(lesson15): rethink color coding and box alignment

### DIFF
--- a/course/lesson-15-modulo/visuals/ExampleModulo.tscn
+++ b/course/lesson-15-modulo/visuals/ExampleModulo.tscn
@@ -7,27 +7,16 @@
 script/source = "tool
 extends RunnableCodeExample
 
+
 func _ready():
 	yield(self, \"ready\")
-	var number_slider = create_slider_for(\"number\", 1, 7, 1)
-	var modulo_slider = create_slider_for(\"modulo\", 1, 7, 1)
-	_scene_instance.connect(\"number_changed\", self, \"_on_number_changed\", [number_slider])
-	_scene_instance.connect(\"modulo_changed\", self, \"_on_modulo_changed\", [modulo_slider])
+	var number_slider = create_slider_for(\"number\", 1, 7, 1, _scene_instance.number_color)
+	var modulo_slider = create_slider_for(\"modulo\", 1, 7, 1, _scene_instance.modulo_color)
 
 
 func _set_instance_value(value: float, property_name: String, value_label: Label) -> void:
 	._set_instance_value(value, property_name, value_label)
 	_gdscript_text_edit.text = gdscript_code.replace(property_name, \"%s [=%s]\"%[property_name, value])
-
-
-func _on_number_changed(number: int, slider: HSlider) -> void:
-	if slider.value != number:
-		slider.value = number
-
-
-func _on_modulo_changed(modulo: int, slider: HSlider) -> void:
-	if slider.value != modulo:
-		slider.value = modulo
 "
 
 [node name="ExampleModulo" type="PanelContainer"]
@@ -37,15 +26,15 @@ margin_bottom = 14.0
 [node name="RunnableCodeExample" parent="." instance=ExtResource( 1 )]
 margin_left = 7.0
 margin_top = 7.0
-margin_right = 307.0
+margin_right = 387.0
 margin_bottom = 387.0
 script = SubResource( 1 )
 scene = ExtResource( 2 )
 
 [node name="Frame" parent="RunnableCodeExample" index="0"]
-margin_right = 300.0
+margin_right = 380.0
 margin_bottom = 380.0
-rect_min_size = Vector2( 300, 380 )
+rect_min_size = Vector2( 380, 380 )
 
 [node name="ResetButton" parent="RunnableCodeExample/Frame/HBoxContainer" index="0"]
 visible = false

--- a/course/lesson-15-modulo/visuals/Modulo.tscn
+++ b/course/lesson-15-modulo/visuals/Modulo.tscn
@@ -1,106 +1,165 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://course/lesson-15-modulo/visuals/Modulo.gd" type="Script" id=1]
-[ext_resource path="res://course/lesson-15-modulo/visuals/square.png" type="Texture" id=2]
 [ext_resource path="res://ui/theme/fonts/font_title.tres" type="DynamicFont" id=3]
+[ext_resource path="res://course/lesson-15-modulo/visuals/Modulo/remainder_stylebox.tres" type="StyleBox" id=4]
+[ext_resource path="res://course/lesson-15-modulo/visuals/Modulo/normal_stylebox.tres" type="StyleBox" id=5]
+
+[sub_resource type="StyleBoxFlat" id=3]
+draw_center = false
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color( 0.14902, 0.776471, 0.968627, 1 )
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_right = 8
+corner_radius_bottom_left = 8
 
 [node name="Modulo" type="Node2D"]
 script = ExtResource( 1 )
-_offset = Vector2( -120, -90 )
 
-[node name="Blocks" type="Node2D" parent="."]
-position = Vector2( 0, 11 )
+[node name="Result" type="Control" parent="."]
+margin_left = -172.0
+margin_top = -90.0
+margin_right = -172.0
+margin_bottom = -90.0
 
-[node name="Block" type="Sprite" parent="Blocks"]
-modulate = Color( 0.572549, 0.560784, 0.721569, 1 )
-position = Vector2( -120, -90 )
-texture = ExtResource( 2 )
+[node name="HBoxContainerBlocks" type="HBoxContainer" parent="Result"]
+margin_right = 344.0
+margin_bottom = 36.0
+rect_min_size = Vector2( 344, 0 )
+custom_constants/separation = 20
 
-[node name="Shadow" type="Sprite" parent="Blocks/Block"]
-modulate = Color( 0.0901961, 0.0941176, 0.188235, 1 )
-show_behind_parent = true
-position = Vector2( 0, 4 )
-texture = ExtResource( 2 )
+[node name="Block" type="Panel" parent="Result/HBoxContainerBlocks"]
+margin_right = 32.0
+margin_bottom = 36.0
+rect_min_size = Vector2( 32, 36 )
+custom_styles/panel = ExtResource( 5 )
 
-[node name="Block2" type="Sprite" parent="Blocks"]
-modulate = Color( 0.572549, 0.560784, 0.721569, 1 )
-position = Vector2( -120, -50 )
-texture = ExtResource( 2 )
-
-[node name="Shadow" type="Sprite" parent="Blocks/Block2"]
-modulate = Color( 0.0901961, 0.0941176, 0.188235, 1 )
-show_behind_parent = true
-position = Vector2( 0, 4 )
-texture = ExtResource( 2 )
-
-[node name="Block3" type="Sprite" parent="Blocks"]
-modulate = Color( 0.572549, 0.560784, 0.721569, 1 )
-position = Vector2( -120, -10 )
-texture = ExtResource( 2 )
-
-[node name="Shadow" type="Sprite" parent="Blocks/Block3"]
-modulate = Color( 0.0901961, 0.0941176, 0.188235, 1 )
-show_behind_parent = true
-position = Vector2( 0, 4 )
-texture = ExtResource( 2 )
-
-[node name="Block4" type="Sprite" parent="Blocks"]
-modulate = Color( 0.239216, 1, 0.431373, 1 )
-position = Vector2( -80, -90 )
-texture = ExtResource( 2 )
-
-[node name="Shadow" type="Sprite" parent="Blocks/Block4"]
-modulate = Color( 0.0901961, 0.0941176, 0.188235, 1 )
-show_behind_parent = true
-position = Vector2( 0, 4 )
-texture = ExtResource( 2 )
-
-[node name="Block5" type="Sprite" parent="Blocks"]
-modulate = Color( 0.239216, 1, 0.431373, 1 )
-position = Vector2( -80, -50 )
-texture = ExtResource( 2 )
-
-[node name="Shadow" type="Sprite" parent="Blocks/Block5"]
-modulate = Color( 0.0901961, 0.0941176, 0.188235, 1 )
-show_behind_parent = true
-position = Vector2( 0, 4 )
-texture = ExtResource( 2 )
-
-[node name="Block6" type="Sprite" parent="Blocks"]
-modulate = Color( 1, 0, 0, 0 )
-position = Vector2( 40, 40 )
-texture = ExtResource( 2 )
-
-[node name="Shadow" type="Sprite" parent="Blocks/Block6"]
-modulate = Color( 0.0901961, 0.0941176, 0.188235, 1 )
-show_behind_parent = true
-position = Vector2( 0, 4 )
-texture = ExtResource( 2 )
-
-[node name="Block7" type="Sprite" parent="Blocks"]
-modulate = Color( 1, 0, 0, 0 )
-position = Vector2( 40, 80 )
-texture = ExtResource( 2 )
-
-[node name="Shadow" type="Sprite" parent="Blocks/Block7"]
-modulate = Color( 0.0901961, 0.0941176, 0.188235, 1 )
-show_behind_parent = true
-position = Vector2( 0, 4 )
-texture = ExtResource( 2 )
-
-[node name="String" type="Label" parent="."]
-margin_left = -84.0
-margin_top = 97.0
+[node name="Block2" type="Panel" parent="Result/HBoxContainerBlocks"]
+margin_left = 52.0
 margin_right = 84.0
-margin_bottom = 128.0
-custom_fonts/font = ExtResource( 3 )
+margin_bottom = 36.0
+rect_min_size = Vector2( 32, 36 )
+custom_styles/panel = ExtResource( 5 )
+
+[node name="Block3" type="Panel" parent="Result/HBoxContainerBlocks"]
+margin_left = 104.0
+margin_right = 136.0
+margin_bottom = 36.0
+rect_min_size = Vector2( 32, 36 )
+custom_styles/panel = ExtResource( 5 )
+
+[node name="Block4" type="Panel" parent="Result/HBoxContainerBlocks"]
+margin_left = 156.0
+margin_right = 188.0
+margin_bottom = 36.0
+rect_min_size = Vector2( 32, 36 )
+custom_styles/panel = ExtResource( 4 )
+
+[node name="Block5" type="Panel" parent="Result/HBoxContainerBlocks"]
+margin_left = 208.0
+margin_right = 240.0
+margin_bottom = 36.0
+rect_min_size = Vector2( 32, 36 )
+custom_styles/panel = ExtResource( 4 )
+
+[node name="Block6" type="Panel" parent="Result/HBoxContainerBlocks"]
+visible = false
+margin_left = 260.0
+margin_right = 292.0
+margin_bottom = 36.0
+rect_min_size = Vector2( 32, 36 )
+custom_styles/panel = ExtResource( 5 )
+
+[node name="Block7" type="Panel" parent="Result/HBoxContainerBlocks"]
+visible = false
+margin_left = 312.0
+margin_right = 344.0
+margin_bottom = 36.0
+rect_min_size = Vector2( 32, 36 )
+custom_styles/panel = ExtResource( 5 )
+
+[node name="HBoxContainerModulo" type="HBoxContainer" parent="Result"]
+margin_left = -8.0
+margin_top = -8.0
+margin_right = 352.0
+margin_bottom = 44.0
+rect_min_size = Vector2( 360, 0 )
+custom_constants/separation = 4
+
+[node name="ModuloHighlight" type="Panel" parent="Result/HBoxContainerModulo"]
+margin_right = 152.0
+margin_bottom = 52.0
+rect_min_size = Vector2( 152, 52 )
+custom_styles/panel = SubResource( 3 )
+
+[node name="ModuloHighlight2" type="Panel" parent="Result/HBoxContainerModulo"]
+visible = false
+margin_left = 156.0
+margin_right = 156.0
+margin_bottom = 52.0
+rect_min_size = Vector2( 0, 52 )
+custom_styles/panel = SubResource( 3 )
+
+[node name="ModuloHighlight3" type="Panel" parent="Result/HBoxContainerModulo"]
+visible = false
+margin_left = 156.0
+margin_right = 156.0
+margin_bottom = 52.0
+rect_min_size = Vector2( 0, 52 )
+custom_styles/panel = SubResource( 3 )
+
+[node name="ModuloHighlight4" type="Panel" parent="Result/HBoxContainerModulo"]
+visible = false
+margin_left = 156.0
+margin_right = 156.0
+margin_bottom = 52.0
+rect_min_size = Vector2( 0, 52 )
+custom_styles/panel = SubResource( 3 )
+
+[node name="ModuloHighlight5" type="Panel" parent="Result/HBoxContainerModulo"]
+visible = false
+margin_left = 156.0
+margin_right = 156.0
+margin_bottom = 52.0
+rect_min_size = Vector2( 0, 52 )
+custom_styles/panel = SubResource( 3 )
+
+[node name="ModuloHighlight6" type="Panel" parent="Result/HBoxContainerModulo"]
+visible = false
+margin_left = 156.0
+margin_right = 156.0
+margin_bottom = 52.0
+rect_min_size = Vector2( 0, 52 )
+custom_styles/panel = SubResource( 3 )
+
+[node name="ModuloHighlight7" type="Panel" parent="Result/HBoxContainerModulo"]
+visible = false
+margin_left = 156.0
+margin_right = 156.0
+margin_bottom = 52.0
+rect_min_size = Vector2( 0, 52 )
+custom_styles/panel = SubResource( 3 )
+
+[node name="String" type="RichTextLabel" parent="."]
+margin_left = -84.0
+margin_top = 100.0
+margin_right = 84.0
+margin_bottom = 131.0
+custom_fonts/normal_font = ExtResource( 3 )
+bbcode_enabled = true
+bbcode_text = "[center][color=#fff5fafa]5[/color] % [color=#ff26c6f7]3[/color][/center]"
 text = "5 % 3"
-align = 1
+scroll_active = false
 
 [node name="Remainder" type="Label" parent="."]
 margin_left = -84.0
-margin_top = 131.0
+margin_top = 140.0
 margin_right = 84.0
-margin_bottom = 162.0
+margin_bottom = 171.0
+custom_colors/font_color = Color( 0.239216, 1, 0.431373, 1 )
 custom_fonts/font = ExtResource( 3 )
 text = "Remainder: 2"

--- a/course/lesson-15-modulo/visuals/Modulo/normal_stylebox.tres
+++ b/course/lesson-15-modulo/visuals/Modulo/normal_stylebox.tres
@@ -1,0 +1,10 @@
+[gd_resource type="StyleBoxFlat" format=2]
+
+[resource]
+bg_color = Color( 0.572549, 0.560784, 0.721569, 1 )
+border_width_bottom = 4
+border_color = Color( 0.960784, 0.980392, 0.980392, 1 )
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4

--- a/course/lesson-15-modulo/visuals/Modulo/remainder_stylebox.tres
+++ b/course/lesson-15-modulo/visuals/Modulo/remainder_stylebox.tres
@@ -1,0 +1,10 @@
+[gd_resource type="StyleBoxFlat" format=2]
+
+[resource]
+bg_color = Color( 0.239216, 1, 0.431373, 1 )
+border_width_bottom = 4
+border_color = Color( 0.960784, 0.980392, 0.980392, 1 )
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4

--- a/ui/components/RunnableCodeExample.gd
+++ b/ui/components/RunnableCodeExample.gd
@@ -7,6 +7,7 @@ extends HBoxContainer
 signal scene_instance_set
 
 const ERROR_NO_RUN_FUNCTION := "Scene %s doesn't have a run() function. The Run button won't work."
+const HSLIDER_GRABBER_HIGHLIGHT := preload("res://ui/theme/hslider_grabber_highlight.tres")
 
 export var scene: PackedScene setget set_scene
 export(String, MULTILINE) var gdscript_code := "" setget set_code
@@ -112,7 +113,7 @@ func set_run_button_label(new_text: String) -> void:
 		_run_button.text = run_button_label
 
 
-func create_slider_for(property_name, min_value := 0.0, max_value := 100.0, step := 1.0) -> HSlider:
+func create_slider_for(property_name, min_value := 0.0, max_value := 100.0, step := 1.0, color := Color.black) -> HSlider:
 	if not _scene_instance:
 		yield(self, "scene_instance_set")
 	var box := HBoxContainer.new()
@@ -134,6 +135,16 @@ func create_slider_for(property_name, min_value := 0.0, max_value := 100.0, step
 	slider.rect_min_size.x = 100.0
 	slider.connect("value_changed", self, "_set_instance_value", [property_name, value_label])
 	_set_instance_value(property_value, property_name, value_label)
+	
+	if color != Color.black:
+		var hslider_grabber_highlight := HSLIDER_GRABBER_HIGHLIGHT.duplicate()
+		hslider_grabber_highlight.bg_color = color
+
+		label.add_color_override("font_color", color)
+		value_label.add_color_override("font_color", color)
+		slider.add_stylebox_override("grabber_area", hslider_grabber_highlight)
+		slider.add_stylebox_override("grabber_area_highlight", hslider_grabber_highlight)
+	
 	return slider
 
 


### PR DESCRIPTION
The example now looks like this:

https://user-images.githubusercontent.com/1177508/157216983-71bb1f6f-3e49-469f-a0ab-898ce4bb311b.mp4

To color-code the sliders I had to add a feature to  `RunnableCodeExample.create_slider_for()` to pass an optional color. This color overrides the color of the labels and the slider stylebox. It will also force only the highlight stylebox be visible at all times, even if the mouse doesn't hover over it.

closes #430