### PR TITLE
fix: Handle optional parameters on move_local_x in lesson 11

### DIFF
--- a/course/lesson-11-time-delta/rotating-and-moving-delta/TestsRotatingMovingDelta.gd
+++ b/course/lesson-11-time-delta/rotating-and-moving-delta/TestsRotatingMovingDelta.gd
@@ -46,7 +46,7 @@ func test_movement_speed_is_correct() -> String:
 	var has_correct_speed := false
 	for line in _lines:
 		has_correct_rotation = has_correct_rotation or line in ["rotate(delta*2)", "rotate(2*delta)"]
-		has_correct_speed = has_correct_speed or line in ["move_local_x(100*delta)", "move_local_x(delta*100)"]
+		has_correct_speed = has_correct_speed or line in ["move_local_x(100*delta)", "move_local_x(delta*100)", "move_local_x(100*delta,false)", "move_local_x(delta*100,false)"]
 	
 	if not has_correct_rotation:
 		return tr("Is the rotation speed correct?")


### PR DESCRIPTION
Apologies, I wasn't able to find your commit message guidelines, so I just matched the styling to my best guess.
Similarly, it looks like the changelog is being handled as a prerelease activity; I did not make a new section with this small change.

- [ ] The commit message follows our guidelines.
- For bug fixes and features:
    - [ ] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #479
