### PR TITLE
fix: updated moving turtle test for lesson 19 to include the starting point

### DIFF
--- a/course/lesson-19-creating-arrays/moving-turtle/TestMovingTurtle.gd
+++ b/course/lesson-19-creating-arrays/moving-turtle/TestMovingTurtle.gd
@@ -14,8 +14,8 @@ func _prepare() -> void:
 func test_path_is_contiguous() -> String:
 	if path.size() == 0:
 		return tr("No points found in variable turtle_path. Did you write Vector2 coordinates in the variable's array?")
-	var last_point = path.front()
-	for point in path.slice(1, path.size() - 1):
+	var last_point = Vector2(0, 0)
+	for point in path.slice(0, path.size() - 1):
 		if not is_equal_approx(last_point.distance_to(point), 1):
 			return tr("We found at least two points that are not next to one another. Did you forget some coordinates, or did you try to move the turtle diagonally?")
 		last_point = point


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #516 

Updated `test_path_is_contiguous` for lesson 19 to use the turtles starting
point when checking if the path is contiguous. This addresses the issue
if the user only provides one point in the array.