### PR TITLE
fix: delta check in the moving in a circle lesson

### DIFF
--- a/course/lesson-11-time-delta/rotating-and-moving-delta/TestsRotatingMovingDelta.gd
+++ b/course/lesson-11-time-delta/rotating-and-moving-delta/TestsRotatingMovingDelta.gd
@@ -33,7 +33,10 @@ func test_moving_in_a_circle() -> String:
 func test_movement_is_time_dependent() -> String:
 	var has_delta := false
 	for line in _lines:
-		has_delta = has_delta and "(delta" in line or "delta)" in line
+		if not "delta" in line.replace(" ", ""):
+			has_delta = false
+			break
+		has_delta = true
 
 	if not has_delta:
 		return tr("Did you use delta in the right places to make the rotation time-dependent?")


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #501

Updated the `test_movement_is_time_dependent` test function to check
if each of the code lines includes the `delta` substring.
