### PR TITLE
Screen size warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,9 @@ addons/godot-plugin-refresher
 # Exports
 build/**/
 
+#custom downloaded templates
+templates/*
+???custom-templates.zip
+
 # Local user overrides
 override.cfg

--- a/html_export/index_template.html
+++ b/html_export/index_template.html
@@ -46,7 +46,7 @@
     <div class="layer mobile-only" id="mobile-warning">
       <div class="mobile-warning-modal notices">
         <p>
-          You appear to be using a mobile browser. This application is not
+          Your browser window seems to be too narrow. This application is not
           suitable for small screens and portrait orientation. If you want to
           continue, it's at your own risk!
         </p>

--- a/html_export/static/style.css
+++ b/html_export/static/style.css
@@ -138,8 +138,9 @@ body {
 .notices {
   font-family: "Noto Sans", "Droid Sans", Arial, sans-serif;
   color: #3b3943;
-  width: 640px;
+  max-width: 640px;
   padding: 3em;
+  margin: 1em;
   background: #fdfdfd;
   box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22);
 }
@@ -180,7 +181,7 @@ body {
   display: none;
 }
 
-@media (orientation: portrait), (max-aspect-ratio: 4/3), (max-width: 750px) {
+@media (orientation: portrait), (max-width: 700px) {
   .mobile-only {
     display: flex;
   }

--- a/html_export/static/style.css
+++ b/html_export/static/style.css
@@ -181,7 +181,7 @@ body {
   display: none;
 }
 
-@media (orientation: portrait), (max-width: 700px) {
+@media (orientation: portrait), (max-width: 700px), (max-height: 400px) {
   .mobile-only {
     display: flex;
   }

--- a/run
+++ b/run
@@ -3,6 +3,9 @@
 
 
 APP_NAME="learn_to_code"
+# This is used while developing to supply the `GODOT_VERSION` variable that is 
+# normally provided by the CI
+local_godot_version=${GODOT_VERSION:-"3.4.4"}
 
 
 ######################################## HELP
@@ -363,6 +366,11 @@ push_all(){
 
 prepare_ci_copytemplates(){
   if [ "$1" == "help" ]; then
+    echo "-- DEPRECATED --"
+    echo "Do not use this, use gettemplates instead"
+    echo "We need to download custom templates to enable offline GDScript error reporting"
+    echo "Once/if this is merged in master, we can use copytemplates again"
+    echo "----------------"
     echo "Prepares the CI by copying the template from the docker"
     echo "You should not run this on your local computer"
     echo "cannot run in dry mode"
@@ -385,7 +393,6 @@ prepare_ci_copytemplates(){
 prepare_ci_gettemplates(){
   if [ "$1" == "help" ]; then
     echo "Prepares the CI by getting the custom templates online"
-    echo "You should not run this on your local computer"
     echo "cannot run in dry mode"
     exit 0
   fi
@@ -496,6 +503,18 @@ prepare_htmltemplate(){
    }@" html_export/index.html
   sed -i "s@%url%@$url@" html_export/index.html
   echo "✓ generated html template"
+}
+
+
+prepare_local(){
+  # TODO: remove this if/when prepare_ci_gettemplates becomes unecessary
+  if [ "$1" == "help" ]; then
+    echo "Downloads the custom templates locally"
+    echo "Necessary before any export"
+    echo "cannot run in dry mode"
+    exit 0
+  fi
+  GODOT_VERSION="$local_godot_version" prepare_ci_gettemplates
 }
 
 


### PR DESCRIPTION
Related issues: 
- #532 
- #448

## Changes

- fixes the CSS of the warning so it fits on any screen
- changes the message to remove the implication of "mobile" and focus on screen size only
- changes the detection logic to not care about aspect ratio, and only trigger under two conditions: either browser window width is under 700px, or height is under 400px, or the orientation is portrait (width < height).

Note: 700px and 400px are arbitrary values. In my personal tests, they seems to be the lowest value after which texts become uncomfortable.

If we want to target mobile users more aggressively with that notice, we can use the media queries `(pointer:none), (pointer:coarse), (hover:none), (hover:on-demand)` (based on [this SO answer](https://stackoverflow.com/questions/12469875/how-to-code-css-media-queries-targeting-all-mobile-devices-and-tablets/42835826#42835826)

Additionally, this PR adds modifications to the run script so we can download the custom export templates locally easily