### PR TITLE
WIP: Blurry fonts

### DIFF
--- a/html_export/static/bootstrap.js
+++ b/html_export/static/bootstrap.js
@@ -68,7 +68,9 @@ window.GDQUEST = ((/** @type {GDQuestLib} */ GDQUEST) => {
       if (!isDebugMode) {
         return { app: true };
       }
-      const modulesList = params.get("debug").split(",").filter(Boolean);
+      const modulesList = (params.get("debug") || "")
+        .split(",")
+        .filter(Boolean);
       if (modulesList.length == 0) {
         return { "*": true };
       }
@@ -186,22 +188,23 @@ window.GDQUEST = ((/** @type {GDQuestLib} */ GDQUEST) => {
       console.error(msg);
       setStatusMode(StatusMode.NOTICE);
       const statusNotice = document.getElementById("notices");
-      msg.split("\n").forEach((line) => {
-        statusNotice.appendChild(document.createTextNode(line));
-        statusNotice.appendChild(document.createElement("br"));
-      });
+      statusNotice &&
+        msg.split("\n").forEach((line) => {
+          statusNotice.appendChild(document.createTextNode(line));
+          statusNotice.appendChild(document.createElement("br"));
+        });
       is_done = true;
     };
 
+    const loaderElement = document.getElementById("loader");
     /**
      * Grows the visual loading bar
      * @param {number} percentage
      * @returns
      */
     const displayPercentage = (percentage = 0) =>
-      document
-        .getElementById("loader")
-        .style.setProperty("--progress", percentage * 100 + "%");
+      loaderElement &&
+      loaderElement.style.setProperty("--progress", percentage * 100 + "%");
 
     /**
      * Callback used during the loading of the engine and packages
@@ -289,9 +292,12 @@ window.GDQUEST = ((/** @type {GDQuestLib} */ GDQUEST) => {
       localStorage.setItem(KEY, "true");
     };
 
-    document
-      .getElementById("mobile-warning-dismiss-button")
-      .addEventListener("click", forceAppOnMobile);
+    const mobileWarningButton = document.getElementById(
+      "mobile-warning-dismiss-button"
+    );
+
+    mobileWarningButton &&
+      mobileWarningButton.addEventListener("click", forceAppOnMobile);
 
     const currentValue = JSON.parse(localStorage.getItem(KEY) || "false");
 
@@ -347,7 +353,7 @@ window.GDQUEST = ((/** @type {GDQuestLib} */ GDQUEST) => {
     const download = () =>
       generateDownloadableFile(
         `gdquest-${Date.now()}.log`,
-        localStorage.getItem(KEY)
+        localStorage.getItem(KEY) || ""
       );
 
     const makeLogFunction =

--- a/html_export/static/bootstrap.js
+++ b/html_export/static/bootstrap.js
@@ -129,15 +129,37 @@ window.GDQUEST = ((/** @type {GDQuestLib} */ GDQUEST) => {
   };
 
   resize: {
+    const snap = (/** @type {number} */ step) => (/** @type {number} */ x) =>
+      Math.trunc(x / step) * step;
+
+    const toWidth = snap(240);
+    const toHeight = snap(135);
+
+    const aspectRatioCanvas = aspectRatio(1920, 1080);
+
+    const snappedAspectRation = () => {
+      const { width, height, ratio } = aspectRatioCanvas(
+        window.innerWidth,
+        window.innerHeight
+      );
+      const _width = toWidth(width);
+      const _height = toHeight(height);
+      return {
+        width: _width,
+        height: _height,
+        ratio: _width / 1920,
+      };
+    };
     const onResize = () => {
-      const { width, height, ratio } = aspectRatioCanvas();
+      const { width, height, ratio } = snappedAspectRation();
       canvas.width = width;
       canvas.height = height;
+      console.log({ width, height, ratio });
       canvasContainer.style.setProperty(`width`, `${width}px`);
       canvasContainer.style.setProperty(`height`, `${height}px`);
       document.documentElement.style.setProperty("--scale", `${ratio}`);
     };
-    const aspectRatioCanvas = aspectRatio(1920, 1080);
+
     window.addEventListener("resize", throttle(GDQUEST.events.onResize.emit));
     GDQUEST.events.onResize.connect(onResize);
     onResize();

--- a/run
+++ b/run
@@ -166,8 +166,8 @@ web_debug(){
     echo "be in your \$PATH"
     exit 0
   fi
+  echo "You need the custom templates. Please make sure to run prepare:local at least once!"
   debug=true
-  prepare_local
   clean_web
   export_web
   web_server &

--- a/run
+++ b/run
@@ -167,6 +167,7 @@ web_debug(){
     exit 0
   fi
   debug=true
+  prepare_local
   clean_web
   export_web
   web_server &
@@ -402,7 +403,10 @@ prepare_ci_gettemplates(){
   fi
   echo "Will get the custom templates for ${GODOT_VERSION}"
   echo "wget https://github.com/Razoric480/godot/releases/download/${GODOT_VERSION}-parser/$(sed 's/\.//g' <<< ${GODOT_VERSION})custom-templates.zip"
-  wget https://github.com/Razoric480/godot/releases/download/${GODOT_VERSION}-parser/$(sed 's/\.//g' <<< ${GODOT_VERSION})custom-templates.zip
+  wget https://github.com/Razoric480/godot/releases/download/${GODOT_VERSION}-parser/$(sed 's/\.//g' <<< ${GODOT_VERSION})custom-templates.zip || {
+    echo "Templates for \`${GODOT_VERSION}\` not found"
+    exit 1
+  }
   echo "✓ Downloaded templates"
   echo "Will unzip templates"
   echo "unzip $(sed 's/\.//g' <<< ${GODOT_VERSION})custom-templates.zip -d templates"


### PR DESCRIPTION
This is related to #381 

## Hypothesis

Because Godot uses rendered fonts, they do not resize as sharply as vector fonts. This is especially apparent if the viewport is not a multiple of the original resolution (1920x1080).

## Fix

The current PR makes sure the viewport resizes to multiples of `240px`. That is, 240, 480, 720, 960, etc. The hope is that pixel division on even numbers will yield sharper results.

This seems to work well enough for me, but it requires more testing.

In parallel, I asked itch to give me access to CSS editing there, so the same setup can be reproduced on the itch page.

Importantly: **we cannot ensure** sharpness if people have custom zoom values set up. A zoom of 72% will always look bad, no matter what. A scale of 125% will similarly result in a pixel division of 0.625, which will create aliasing on the edges.

If we wanted to go around that, we'd need:

1. to pass the current window size to Godot through the javascript API
2. have Godot use a different font size dependent on passed the window size
3. have Godot lock the size in increments of 240 too (set the mode to not stretch, and handle viewport changes ourselves)

This is also what we would need to do if we want to handle blurriness on Desktops.

It's possible, but I don't know if it is worth it at the moment. Godot 4 has automatic font scaling, so the problem could potentially be less visible once we port.