### PR TITLE
Fix navigating multiple times

### DIFF
--- a/ui/UINavigator.gd
+++ b/ui/UINavigator.gd
@@ -24,6 +24,7 @@ var _matches := {}
 
 var _lesson_index := 0
 var _lesson_count: int = 0
+var _is_navigating_to: bool = false
 
 onready var _home_button := $Layout/Header/MarginContainer/HeaderContent/HomeButton as Button
 onready var _outliner_button := $Layout/Header/MarginContainer/HeaderContent/OutlinerButton as Button
@@ -137,6 +138,10 @@ func _navigate_to_outliner() -> void:
 
 # Navigates forward to the next screen and adds it to the stack.
 func _navigate_to() -> void:
+	if _is_navigating_to: return
+	
+	_is_navigating_to = true
+	
 	var target := NavigationManager.get_navigation_resource(NavigationManager.current_url)
 	var screen: UINavigatablePage
 	if target is Practice:
@@ -154,6 +159,7 @@ func _navigate_to() -> void:
 		_lesson_index = course.lessons.find(lesson) # Make sure the index is synced after navigation.
 	else:
 		printerr("Trying to navigate to unsupported resource type: %s" % target.get_class())
+		_is_navigating_to = false
 		return
 
 	_outliner_button.show()
@@ -191,6 +197,8 @@ func _navigate_to() -> void:
 		Events.emit_signal("practice_started", target)
 	elif target is Lesson:
 		Events.emit_signal("lesson_started", target)
+	
+	_is_navigating_to = false
 
 
 func _on_practice_next_requested(practice: Practice) -> void:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.

**What kind of change does this PR introduce?**
When clicking a button to navigate to a different screen multiple times quickly (sometthing users might do if the screen transition is slowish; I did this with a loading time of ~1sec), the next screen will appear repeatedly, causing a lag and bugging the breadcrumbs (only one instance of the next screen will appear in the breadcrumbs, not the whole stack of repeated screens). Lessons in particular will also appear with glitched text (probably something related to the bbcode formatting regex).

This fixes this behaviour. It creates a safe variable on _navigate_to() so it only navigates to the next screen after it finishes the transition the first time it was called.


**Does this PR introduce a breaking change?**
Nope.