### PR TITLE
fix #611

### DIFF
--- a/course/lesson-9-adding-and-subtracting/lesson.tres
+++ b/course/lesson-9-adding-and-subtracting/lesson.tres
@@ -126,7 +126,7 @@ func take_damage(amount):
 	"
 cursor_line = 0
 cursor_column = 0
-hints = PoolStringArray( "Replace [code]pass[/code] with an instruction to subtract [code]amount[/code] from [code]health[/code]." )
+hints = PoolStringArray( "Add an instruction to subtract [code]amount[/code] from [code]health[/code]." )
 validator_script_path = "taking-damage/TestDamagingRobot.gd"
 script_slice_path = "taking-damage/DamagingRobot.live-editor/slices/DamagingRobot.damage.slice.tres"
 documentation_references = PoolStringArray( "take_damage" )


### PR DESCRIPTION
This removes the `pass` hint from lesson 9 practice (the keyword is later explained on lesson 13)
