### PR TITLE
feat: add option to change text color

### DIFF
--- a/autoload/ThemeManager.gd
+++ b/autoload/ThemeManager.gd
@@ -3,6 +3,8 @@ extends Node
 const THEME_ROOT := "res://ui/theme/"
 const THEME_FONTS_ROOT := "res://ui/theme/fonts/"
 
+onready var _theme = preload("res://ui/theme/gdscript_app_theme.tres")
+
 var _font_size_defaults := {}
 
 
@@ -11,6 +13,7 @@ func _ready() -> void:
 	
 	var current_profile := UserProfiles.get_profile()
 	scale_all_font_sizes(current_profile.font_size_scale, false)
+	change_font_color(current_profile.font_color, false)
 
 
 func _cache_font_size_defaults() -> void:
@@ -57,3 +60,12 @@ func scale_all_font_sizes(size_scale: int, and_save: bool = true) -> void:
 		current_profile.font_size_scale = size_scale
 		current_profile.save()
 		Events.emit_signal("font_size_scale_changed", size_scale)
+
+func change_font_color(color: Color, and_save: bool = true) -> void:
+	_theme.set_color("font_color", "Label", color)
+	_theme.set_color("default_color", "RichTextLabel", color)
+	
+	if and_save:
+		var current_profile := UserProfiles.get_profile()
+		current_profile.font_color = color
+		current_profile.save()

--- a/autoload/ThemeManager.gd
+++ b/autoload/ThemeManager.gd
@@ -3,6 +3,9 @@ extends Node
 const THEME_ROOT := "res://ui/theme/"
 const THEME_FONTS_ROOT := "res://ui/theme/fonts/"
 
+const DEFAULT_COLOR := Color.white
+const LOWER_CONTRAST_COLOR := Color.darkgray
+
 onready var _theme = preload("res://ui/theme/gdscript_app_theme.tres")
 
 var _font_size_defaults := {}
@@ -13,7 +16,7 @@ func _ready() -> void:
 	
 	var current_profile := UserProfiles.get_profile()
 	scale_all_font_sizes(current_profile.font_size_scale, false)
-	change_font_color(current_profile.font_color, false)
+	change_lower_contrast(current_profile.lower_contrast, false)
 
 
 func _cache_font_size_defaults() -> void:
@@ -61,11 +64,15 @@ func scale_all_font_sizes(size_scale: int, and_save: bool = true) -> void:
 		current_profile.save()
 		Events.emit_signal("font_size_scale_changed", size_scale)
 
-func change_font_color(color: Color, and_save: bool = true) -> void:
-	_theme.set_color("font_color", "Label", color)
-	_theme.set_color("default_color", "RichTextLabel", color)
+func change_lower_contrast(lower_contrast: bool, and_save: bool = true) -> void:
+	if (lower_contrast):
+		_theme.set_color("font_color", "Label", LOWER_CONTRAST_COLOR)
+		_theme.set_color("default_color", "RichTextLabel", LOWER_CONTRAST_COLOR)
+	else:
+		_theme.set_color("font_color", "Label", DEFAULT_COLOR)
+		_theme.set_color("default_color", "RichTextLabel", DEFAULT_COLOR)
 	
 	if and_save:
 		var current_profile := UserProfiles.get_profile()
-		current_profile.font_color = color
+		current_profile.lower_contrast = lower_contrast
 		current_profile.save()

--- a/autoload/ThemeManager.gd
+++ b/autoload/ThemeManager.gd
@@ -3,8 +3,8 @@ extends Node
 const THEME_ROOT := "res://ui/theme/"
 const THEME_FONTS_ROOT := "res://ui/theme/fonts/"
 
-const DEFAULT_COLOR := Color.white
-const LOWER_CONTRAST_COLOR := Color.darkgray
+const COLOR_TEXT_DEFAULT := Color(0.960784, 0.980392, 0.980392)
+const COLOR_TEXT_LOWER_CONTRAST := Color(0.736288, 0.728113, 0.839844)
 
 onready var _theme = preload("res://ui/theme/gdscript_app_theme.tres")
 
@@ -16,7 +16,7 @@ func _ready() -> void:
 	
 	var current_profile := UserProfiles.get_profile()
 	scale_all_font_sizes(current_profile.font_size_scale, false)
-	change_lower_contrast(current_profile.lower_contrast, false)
+	set_lower_contrast(current_profile.lower_contrast, false)
 
 
 func _cache_font_size_defaults() -> void:
@@ -64,14 +64,12 @@ func scale_all_font_sizes(size_scale: int, and_save: bool = true) -> void:
 		current_profile.save()
 		Events.emit_signal("font_size_scale_changed", size_scale)
 
-func change_lower_contrast(lower_contrast: bool, and_save: bool = true) -> void:
-	if (lower_contrast):
-		_theme.set_color("font_color", "Label", LOWER_CONTRAST_COLOR)
-		_theme.set_color("default_color", "RichTextLabel", LOWER_CONTRAST_COLOR)
-	else:
-		_theme.set_color("font_color", "Label", DEFAULT_COLOR)
-		_theme.set_color("default_color", "RichTextLabel", DEFAULT_COLOR)
-	
+
+func set_lower_contrast(lower_contrast: bool, and_save: bool = true) -> void:
+	var color := COLOR_TEXT_LOWER_CONTRAST if lower_contrast else COLOR_TEXT_DEFAULT
+	_theme.set_color("font_color", "Label", color)
+	_theme.set_color("default_color", "RichTextLabel", color)
+
 	if and_save:
 		var current_profile := UserProfiles.get_profile()
 		current_profile.lower_contrast = lower_contrast

--- a/resources/Profile.gd
+++ b/resources/Profile.gd
@@ -20,6 +20,8 @@ export var is_sponsored_profile := true
 export var language := "en"
 # Relative size adjustment of all fonts, in integer numbers.
 export var font_size_scale := 0
+# Font Color
+export var font_color := Color(255,255,255,255)
 # Sensitivity when scrolling with the mouse wheel or touchpad.
 export var scroll_sensitivity := 1.0 setget set_scroll_sensitivity
 # Target framerate for the application, to reduce update intensity on lower end devices.

--- a/resources/Profile.gd
+++ b/resources/Profile.gd
@@ -20,8 +20,8 @@ export var is_sponsored_profile := true
 export var language := "en"
 # Relative size adjustment of all fonts, in integer numbers.
 export var font_size_scale := 0
-# Font Color
-export var font_color := Color(255,255,255,255)
+# Lower contrast enabled
+export var lower_contrast := false
 # Sensitivity when scrolling with the mouse wheel or touchpad.
 export var scroll_sensitivity := 1.0 setget set_scroll_sensitivity
 # Target framerate for the application, to reduce update intensity on lower end devices.

--- a/ui/components/popups/SettingsPopup.gd
+++ b/ui/components/popups/SettingsPopup.gd
@@ -19,9 +19,7 @@ onready var _font_size_sample := $PanelContainer/Column/Margin/Column/Settings/F
 onready var _scroll_sensitivity_slider := $PanelContainer/Column/Margin/Column/Settings/ScrollSensitivitySetting/Value as HSlider
 onready var _framerate_option := $PanelContainer/Column/Margin/Column/Settings/FramerateSetting/Value as OptionButton
 
-onready var _font_color := $PanelContainer/Column/Margin/Column/TextColorSetting/ColorContainer/ColorPickerButton as ColorPickerButton
-onready var _font_color_sample := $PanelContainer/Column/Margin/Column/TextColorSetting/ColorContainer/SampleText as Label
-
+onready var _lower_contrast := $PanelContainer/Column/Margin/Column/Settings/LowerContrasSetting/CheckButton as CheckButton
 
 onready var _apply_button := $PanelContainer/Column/Margin/Column/Buttons/ApplyButton as Button
 onready var _cancel_button := $PanelContainer/Column/Margin/Column/Buttons/CancelButton as Button
@@ -37,7 +35,6 @@ func _ready() -> void:
 	_init_values()
 	
 	_font_size_value.connect("value_changed", self, "_on_font_size_changed")
-	_font_color.connect("color_changed", self, "_on_font_color_changed")
 	
 	_apply_button.connect("pressed", self, "_on_apply_settings")
 	_cancel_button.connect("pressed", self, "hide")
@@ -80,7 +77,7 @@ func _init_values() -> void:
 	_scroll_sensitivity_slider.value = current_profile.scroll_sensitivity
 	_framerate_option.selected = FRAMERATE_MAP.values().find(current_profile.framerate_limit)
 	
-	_font_color.color = current_profile.font_color
+	_lower_contrast.pressed = current_profile.lower_contrast
 
 
 func _on_apply_settings() -> void:
@@ -89,8 +86,8 @@ func _on_apply_settings() -> void:
 	var size_scale := int(_font_size_value.value)
 	ThemeManager.scale_all_font_sizes(size_scale)
 	
-	ThemeManager.change_font_color(_font_color.color)
-	
+	ThemeManager.change_lower_contrast(_lower_contrast.pressed)
+
 	current_profile.set_scroll_sensitivity(_scroll_sensitivity_slider.value)
 	current_profile.set_framerate_limit(FRAMERATE_MAP[_framerate_option.selected])
 	
@@ -102,11 +99,6 @@ func _on_font_size_changed(value: int) -> void:
 	var font_override = _sample_default_font.duplicate() as DynamicFont
 	font_override.size += 2 * value
 	_font_size_sample.add_font_override("font", font_override)
-
-
-func _on_font_color_changed(color: Color) -> void:
-	_font_color_sample.add_color_override("font_color", color)
-
 
 func _on_visibility_changed() -> void:
 	if _panel.visible:

--- a/ui/components/popups/SettingsPopup.gd
+++ b/ui/components/popups/SettingsPopup.gd
@@ -19,7 +19,7 @@ onready var _font_size_sample := $PanelContainer/Column/Margin/Column/Settings/F
 onready var _scroll_sensitivity_slider := $PanelContainer/Column/Margin/Column/Settings/ScrollSensitivitySetting/Value as HSlider
 onready var _framerate_option := $PanelContainer/Column/Margin/Column/Settings/FramerateSetting/Value as OptionButton
 
-onready var _lower_contrast := $PanelContainer/Column/Margin/Column/Settings/LowerContrasSetting/CheckButton as CheckButton
+onready var _lower_contrast := $PanelContainer/Column/Margin/Column/Settings/LowerContrasSetting/CheckBox as CheckBox
 
 onready var _apply_button := $PanelContainer/Column/Margin/Column/Buttons/ApplyButton as Button
 onready var _cancel_button := $PanelContainer/Column/Margin/Column/Buttons/CancelButton as Button
@@ -86,7 +86,7 @@ func _on_apply_settings() -> void:
 	var size_scale := int(_font_size_value.value)
 	ThemeManager.scale_all_font_sizes(size_scale)
 	
-	ThemeManager.change_lower_contrast(_lower_contrast.pressed)
+	ThemeManager.set_lower_contrast(_lower_contrast.pressed)
 
 	current_profile.set_scroll_sensitivity(_scroll_sensitivity_slider.value)
 	current_profile.set_framerate_limit(FRAMERATE_MAP[_framerate_option.selected])

--- a/ui/components/popups/SettingsPopup.gd
+++ b/ui/components/popups/SettingsPopup.gd
@@ -19,6 +19,10 @@ onready var _font_size_sample := $PanelContainer/Column/Margin/Column/Settings/F
 onready var _scroll_sensitivity_slider := $PanelContainer/Column/Margin/Column/Settings/ScrollSensitivitySetting/Value as HSlider
 onready var _framerate_option := $PanelContainer/Column/Margin/Column/Settings/FramerateSetting/Value as OptionButton
 
+onready var _font_color := $PanelContainer/Column/Margin/Column/TextColorSetting/ColorContainer/ColorPickerButton as ColorPickerButton
+onready var _font_color_sample := $PanelContainer/Column/Margin/Column/TextColorSetting/ColorContainer/SampleText as Label
+
+
 onready var _apply_button := $PanelContainer/Column/Margin/Column/Buttons/ApplyButton as Button
 onready var _cancel_button := $PanelContainer/Column/Margin/Column/Buttons/CancelButton as Button
 
@@ -33,6 +37,7 @@ func _ready() -> void:
 	_init_values()
 	
 	_font_size_value.connect("value_changed", self, "_on_font_size_changed")
+	_font_color.connect("color_changed", self, "_on_font_color_changed")
 	
 	_apply_button.connect("pressed", self, "_on_apply_settings")
 	_cancel_button.connect("pressed", self, "hide")
@@ -74,6 +79,8 @@ func _init_values() -> void:
 	)
 	_scroll_sensitivity_slider.value = current_profile.scroll_sensitivity
 	_framerate_option.selected = FRAMERATE_MAP.values().find(current_profile.framerate_limit)
+	
+	_font_color.color = current_profile.font_color
 
 
 func _on_apply_settings() -> void:
@@ -81,6 +88,8 @@ func _on_apply_settings() -> void:
 	
 	var size_scale := int(_font_size_value.value)
 	ThemeManager.scale_all_font_sizes(size_scale)
+	
+	ThemeManager.change_font_color(_font_color.color)
 	
 	current_profile.set_scroll_sensitivity(_scroll_sensitivity_slider.value)
 	current_profile.set_framerate_limit(FRAMERATE_MAP[_framerate_option.selected])
@@ -93,6 +102,10 @@ func _on_font_size_changed(value: int) -> void:
 	var font_override = _sample_default_font.duplicate() as DynamicFont
 	font_override.size += 2 * value
 	_font_size_sample.add_font_override("font", font_override)
+
+
+func _on_font_color_changed(color: Color) -> void:
+	_font_color_sample.add_color_override("font_color", color)
 
 
 func _on_visibility_changed() -> void:

--- a/ui/components/popups/SettingsPopup.tscn
+++ b/ui/components/popups/SettingsPopup.tscn
@@ -41,12 +41,12 @@ __meta__ = {
 
 [node name="Panel" type="Panel" parent="PanelContainer"]
 margin_right = 720.0
-margin_bottom = 605.0
+margin_bottom = 599.0
 custom_styles/panel = ExtResource( 5 )
 
 [node name="Column" type="VBoxContainer" parent="PanelContainer"]
 margin_right = 720.0
-margin_bottom = 605.0
+margin_bottom = 599.0
 custom_constants/separation = 0
 
 [node name="ProgressBar" type="ProgressBar" parent="PanelContainer/Column"]
@@ -59,14 +59,14 @@ percent_visible = false
 [node name="Margin" type="MarginContainer" parent="PanelContainer/Column"]
 margin_top = 16.0
 margin_right = 720.0
-margin_bottom = 605.0
+margin_bottom = 599.0
 size_flags_vertical = 3
 
 [node name="Column" type="VBoxContainer" parent="PanelContainer/Column/Margin"]
 margin_left = 20.0
 margin_top = 20.0
 margin_right = 700.0
-margin_bottom = 569.0
+margin_bottom = 563.0
 custom_constants/separation = 12
 
 [node name="Title" type="Label" parent="PanelContainer/Column/Margin/Column"]
@@ -87,33 +87,33 @@ size_flags_horizontal = 4
 [node name="Settings" type="VBoxContainer" parent="PanelContainer/Column/Margin/Column"]
 margin_top = 63.0
 margin_right = 680.0
-margin_bottom = 437.0
+margin_bottom = 431.0
 size_flags_vertical = 3
 custom_constants/separation = 32
 
 [node name="LanguageSetting" type="HBoxContainer" parent="PanelContainer/Column/Margin/Column/Settings"]
 margin_right = 680.0
-margin_bottom = 47.0
+margin_bottom = 44.0
 
 [node name="Label" type="Label" parent="PanelContainer/Column/Margin/Column/Settings/LanguageSetting"]
-margin_top = 9.0
+margin_top = 8.0
 margin_right = 332.0
-margin_bottom = 37.0
+margin_bottom = 36.0
 size_flags_horizontal = 3
 text = "Language"
 
 [node name="Value" type="OptionButton" parent="PanelContainer/Column/Margin/Column/Settings/LanguageSetting"]
 margin_left = 348.0
 margin_right = 680.0
-margin_bottom = 47.0
+margin_bottom = 44.0
 hint_tooltip = "Change the course's language. We plan to add other languages, but only English is available for now."
 size_flags_horizontal = 3
 text = "English"
 
 [node name="FontSizeSetting" type="HBoxContainer" parent="PanelContainer/Column/Margin/Column/Settings"]
-margin_top = 79.0
+margin_top = 76.0
 margin_right = 680.0
-margin_bottom = 155.0
+margin_bottom = 152.0
 
 [node name="Label" type="Label" parent="PanelContainer/Column/Margin/Column/Settings/FontSizeSetting"]
 margin_right = 332.0
@@ -152,9 +152,9 @@ text = "Sample text"
 align = 1
 
 [node name="ScrollSensitivitySetting" type="HBoxContainer" parent="PanelContainer/Column/Margin/Column/Settings"]
-margin_top = 187.0
+margin_top = 184.0
 margin_right = 680.0
-margin_bottom = 215.0
+margin_bottom = 212.0
 
 [node name="Label" type="Label" parent="PanelContainer/Column/Margin/Column/Settings/ScrollSensitivitySetting"]
 margin_right = 332.0
@@ -178,9 +178,9 @@ tick_count = 2
 ticks_on_borders = true
 
 [node name="FramerateSetting" type="HBoxContainer" parent="PanelContainer/Column/Margin/Column/Settings"]
-margin_top = 247.0
+margin_top = 244.0
 margin_right = 680.0
-margin_bottom = 294.0
+margin_bottom = 288.0
 
 [node name="Label" type="Label" parent="PanelContainer/Column/Margin/Column/Settings/FramerateSetting"]
 margin_right = 332.0
@@ -192,7 +192,7 @@ text = "Framerate cap"
 [node name="Value" type="OptionButton" parent="PanelContainer/Column/Margin/Column/Settings/FramerateSetting"]
 margin_left = 348.0
 margin_right = 680.0
-margin_bottom = 47.0
+margin_bottom = 44.0
 hint_tooltip = "Limit the app's framerate. Lower values make the app use less resources, especially when running in the browser, but may feel less fluid."
 size_flags_horizontal = 3
 text = "60 FPS"
@@ -200,9 +200,9 @@ items = [ "60 FPS", null, false, 0, false, "30 FPS", null, false, 0, false, "No 
 selected = 0
 
 [node name="LowerContrasSetting" type="HBoxContainer" parent="PanelContainer/Column/Margin/Column/Settings"]
-margin_top = 326.0
+margin_top = 320.0
 margin_right = 680.0
-margin_bottom = 374.0
+margin_bottom = 368.0
 
 [node name="Label" type="Label" parent="PanelContainer/Column/Margin/Column/Settings/LowerContrasSetting"]
 margin_right = 332.0
@@ -211,23 +211,24 @@ size_flags_horizontal = 3
 size_flags_vertical = 0
 text = "Lower contrast"
 
-[node name="CheckButton" type="CheckButton" parent="PanelContainer/Column/Margin/Column/Settings/LowerContrasSetting"]
+[node name="CheckBox" type="CheckBox" parent="PanelContainer/Column/Margin/Column/Settings/LowerContrasSetting"]
 margin_left = 348.0
 margin_right = 680.0
 margin_bottom = 48.0
+hint_tooltip = "Lower the text's brightness."
 size_flags_horizontal = 3
 text = "Enabled"
 
 [node name="Spacer" type="Control" parent="PanelContainer/Column/Margin/Column"]
-margin_top = 449.0
+margin_top = 443.0
 margin_right = 680.0
-margin_bottom = 469.0
+margin_bottom = 463.0
 rect_min_size = Vector2( 400, 20 )
 
 [node name="Buttons" type="HBoxContainer" parent="PanelContainer/Column/Margin/Column"]
-margin_top = 481.0
+margin_top = 475.0
 margin_right = 680.0
-margin_bottom = 549.0
+margin_bottom = 543.0
 alignment = 1
 
 [node name="CancelButton" type="Button" parent="PanelContainer/Column/Margin/Column/Buttons"]

--- a/ui/components/popups/SettingsPopup.tscn
+++ b/ui/components/popups/SettingsPopup.tscn
@@ -23,9 +23,6 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 theme = ExtResource( 7 )
 color = Color( 0.0352941, 0.0392157, 0.129412, 0.627451 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
 anchor_left = 0.5
@@ -44,12 +41,12 @@ __meta__ = {
 
 [node name="Panel" type="Panel" parent="PanelContainer"]
 margin_right = 720.0
-margin_bottom = 540.0
+margin_bottom = 605.0
 custom_styles/panel = ExtResource( 5 )
 
 [node name="Column" type="VBoxContainer" parent="PanelContainer"]
 margin_right = 720.0
-margin_bottom = 540.0
+margin_bottom = 605.0
 custom_constants/separation = 0
 
 [node name="ProgressBar" type="ProgressBar" parent="PanelContainer/Column"]
@@ -62,14 +59,14 @@ percent_visible = false
 [node name="Margin" type="MarginContainer" parent="PanelContainer/Column"]
 margin_top = 16.0
 margin_right = 720.0
-margin_bottom = 540.0
+margin_bottom = 605.0
 size_flags_vertical = 3
 
 [node name="Column" type="VBoxContainer" parent="PanelContainer/Column/Margin"]
 margin_left = 20.0
 margin_top = 20.0
 margin_right = 700.0
-margin_bottom = 504.0
+margin_bottom = 569.0
 custom_constants/separation = 12
 
 [node name="Title" type="Label" parent="PanelContainer/Column/Margin/Column"]
@@ -90,7 +87,7 @@ size_flags_horizontal = 4
 [node name="Settings" type="VBoxContainer" parent="PanelContainer/Column/Margin/Column"]
 margin_top = 63.0
 margin_right = 680.0
-margin_bottom = 372.0
+margin_bottom = 437.0
 size_flags_vertical = 3
 custom_constants/separation = 32
 
@@ -202,51 +199,35 @@ text = "60 FPS"
 items = [ "60 FPS", null, false, 0, false, "30 FPS", null, false, 0, false, "No limit", null, false, 0, false ]
 selected = 0
 
-[node name="TextColorSetting" type="HBoxContainer" parent="PanelContainer/Column/Margin/Column"]
-margin_top = 369.0
+[node name="LowerContrasSetting" type="HBoxContainer" parent="PanelContainer/Column/Margin/Column/Settings"]
+margin_top = 326.0
 margin_right = 680.0
-margin_bottom = 468.0
+margin_bottom = 374.0
 
-[node name="Label" type="Label" parent="PanelContainer/Column/Margin/Column/TextColorSetting"]
+[node name="Label" type="Label" parent="PanelContainer/Column/Margin/Column/Settings/LowerContrasSetting"]
 margin_right = 332.0
 margin_bottom = 28.0
 size_flags_horizontal = 3
 size_flags_vertical = 0
-text = "Text Color"
+text = "Lower contrast"
 
-[node name="ColorContainer" type="VBoxContainer" parent="PanelContainer/Column/Margin/Column/TextColorSetting"]
+[node name="CheckButton" type="CheckButton" parent="PanelContainer/Column/Margin/Column/Settings/LowerContrasSetting"]
 margin_left = 348.0
 margin_right = 680.0
-margin_bottom = 99.0
+margin_bottom = 48.0
 size_flags_horizontal = 3
-custom_constants/separation = 12
-
-[node name="ColorPickerButton" type="ColorPickerButton" parent="PanelContainer/Column/Margin/Column/TextColorSetting/ColorContainer"]
-margin_right = 332.0
-margin_bottom = 47.0
-hint_tooltip = "Change the color of all text in the app."
-size_flags_horizontal = 3
-color = Color( 1, 1, 1, 1 )
-
-[node name="SampleText" type="Label" parent="PanelContainer/Column/Margin/Column/TextColorSetting/ColorContainer"]
-margin_top = 59.0
-margin_right = 332.0
-margin_bottom = 99.0
-rect_min_size = Vector2( 0, 40 )
-size_flags_horizontal = 3
-text = "Sample text"
-align = 1
+text = "Enabled"
 
 [node name="Spacer" type="Control" parent="PanelContainer/Column/Margin/Column"]
-margin_top = 480.0
+margin_top = 449.0
 margin_right = 680.0
-margin_bottom = 500.0
+margin_bottom = 469.0
 rect_min_size = Vector2( 400, 20 )
 
 [node name="Buttons" type="HBoxContainer" parent="PanelContainer/Column/Margin/Column"]
-margin_top = 512.0
+margin_top = 481.0
 margin_right = 680.0
-margin_bottom = 580.0
+margin_bottom = 549.0
 alignment = 1
 
 [node name="CancelButton" type="Button" parent="PanelContainer/Column/Margin/Column/Buttons"]

--- a/ui/components/popups/SettingsPopup.tscn
+++ b/ui/components/popups/SettingsPopup.tscn
@@ -202,16 +202,51 @@ text = "60 FPS"
 items = [ "60 FPS", null, false, 0, false, "30 FPS", null, false, 0, false, "No limit", null, false, 0, false ]
 selected = 0
 
-[node name="Spacer" type="Control" parent="PanelContainer/Column/Margin/Column"]
-margin_top = 384.0
+[node name="TextColorSetting" type="HBoxContainer" parent="PanelContainer/Column/Margin/Column"]
+margin_top = 369.0
 margin_right = 680.0
-margin_bottom = 404.0
+margin_bottom = 468.0
+
+[node name="Label" type="Label" parent="PanelContainer/Column/Margin/Column/TextColorSetting"]
+margin_right = 332.0
+margin_bottom = 28.0
+size_flags_horizontal = 3
+size_flags_vertical = 0
+text = "Text Color"
+
+[node name="ColorContainer" type="VBoxContainer" parent="PanelContainer/Column/Margin/Column/TextColorSetting"]
+margin_left = 348.0
+margin_right = 680.0
+margin_bottom = 99.0
+size_flags_horizontal = 3
+custom_constants/separation = 12
+
+[node name="ColorPickerButton" type="ColorPickerButton" parent="PanelContainer/Column/Margin/Column/TextColorSetting/ColorContainer"]
+margin_right = 332.0
+margin_bottom = 47.0
+hint_tooltip = "Change the color of all text in the app."
+size_flags_horizontal = 3
+color = Color( 1, 1, 1, 1 )
+
+[node name="SampleText" type="Label" parent="PanelContainer/Column/Margin/Column/TextColorSetting/ColorContainer"]
+margin_top = 59.0
+margin_right = 332.0
+margin_bottom = 99.0
+rect_min_size = Vector2( 0, 40 )
+size_flags_horizontal = 3
+text = "Sample text"
+align = 1
+
+[node name="Spacer" type="Control" parent="PanelContainer/Column/Margin/Column"]
+margin_top = 480.0
+margin_right = 680.0
+margin_bottom = 500.0
 rect_min_size = Vector2( 400, 20 )
 
 [node name="Buttons" type="HBoxContainer" parent="PanelContainer/Column/Margin/Column"]
-margin_top = 416.0
+margin_top = 512.0
 margin_right = 680.0
-margin_bottom = 484.0
+margin_bottom = 580.0
 alignment = 1
 
 [node name="CancelButton" type="Button" parent="PanelContainer/Column/Margin/Column/Buttons"]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #623


**What kind of change does this PR introduce?**
Adds new Setting **Text Color** to the SettingsPopup to change the color of all (`Label ` and  `RichTextLabel` ) text in the app.
Color setting is also stored to the `Profile`.

## New feature or change ##

![image](https://user-images.githubusercontent.com/16044116/193683838-cbdc4e4f-eaab-474c-8595-60f1a49e61c6.png)

![image](https://user-images.githubusercontent.com/16044116/193683852-b5830614-b58b-412c-aeb8-503168e8c8b1.png)

![image](https://user-images.githubusercontent.com/16044116/193683866-3afc832b-60f8-469a-9f86-9ee994c52845.png)
![image](https://user-images.githubusercontent.com/16044116/193683885-9ccd76a3-3c9b-4c66-88c4-b43a77cb9e74.png)


**Other information**
Maybe its not the best idea to change `Label ` and  `RichTextLabel` or probably there are Control Nodes who should change color.