### PR TITLE
Fix Lesson 3 example and stop examples with no debuggers from resetting every `run()`.

### DIFF
--- a/course/lesson-3-standing-on-shoulders-of-giants/ExampleMoveSprite.tscn
+++ b/course/lesson-3-standing-on-shoulders-of-giants/ExampleMoveSprite.tscn
@@ -6,7 +6,8 @@
 [sub_resource type="GDScript" id=1]
 script/source = "extends WrappingNode2D
 
-onready var start_position = position
+onready var start_position = null
+
 
 func _ready() -> void:
 	_sprites = [$Pivot/HandIceLeft, $Pivot/HandIceRight, $Pivot/RobotBody]
@@ -20,6 +21,8 @@ func run():
 
 
 func reset():
+	if start_position == null:
+		start_position = position
 	position = start_position
 	_bounds = calculate_bounding_rect(_sprites)
 "

--- a/ui/components/RunnableCodeExample.gd
+++ b/ui/components/RunnableCodeExample.gd
@@ -87,7 +87,10 @@ func run() -> void:
 			_scene_instance.has_method("run"), "Node %s does not have a run method" % [get_path()]
 		)
 
-		if _scene_instance.has_method("reset"):
+		# Some examples expect to be able to play them from the previous state,
+		# while others don't. In general, we only need to reset a demo
+		# to its initial state if it has a Debugger node.
+		if _scene_instance.has_method("reset") and _debugger:
 			_scene_instance.reset()
 
 		# warning-ignore:unsafe_method_access


### PR DESCRIPTION
Fix #694 .

One problem that I also fix on this PR is the fact that examples now reset every time `run()` is pressed. I added this with the Debugger node because no code example with the debugger made sense to store the state of the variables between `run()`'s, and I needed to reset it to a default `unassigned` value. But some examples (specially the first ones) expect the user to play `run()` more than once with the previous state in mind (e.g. rotating a sprite).

What this PR does is to check when the user presses `run()` whether the example has a `debugger` node. If and only if it has, it resets.