### PR TITLE
Fix/706 lesson 11 test bug

### DIFF
--- a/course/lesson-11-time-delta/rotating-using-delta/TestsRotatingDelta.gd
+++ b/course/lesson-11-time-delta/rotating-using-delta/TestsRotatingDelta.gd
@@ -105,8 +105,7 @@ func test_rotation_speed_is_2_radians_per_second() -> String:
 		var result = regex_has_two.search(_body)
 		if result:
 			has_two = true
-		
-		print("has_two:", has_two)
+
 		if not has_two:
 			return tr("Is the rotation speed correct?")
 		elif not has_multiplication_sign:

--- a/course/lesson-11-time-delta/rotating-using-delta/TestsRotatingDelta.gd
+++ b/course/lesson-11-time-delta/rotating-using-delta/TestsRotatingDelta.gd
@@ -22,15 +22,44 @@ func _prepare() -> void:
 
 func test_rotating_character_is_time_dependent() -> String:
 	if not _has_proper_body:
+		#reverse find for any delta at all
 		var has_delta: bool = _body.rfind("delta") > 0
-		var is_in_parentheses: bool = _body.rfind(")")
+		#set parentheses found false by default
+		var is_in_parentheses: bool = false
 
+		#Regular expression to check if delta is inside parenthesis
+		#I know, regexp is ancient evil magic:
+		#  Some people, when confronted with a problem, think
+		#  "I know, I'll use regular expressions" 
+		#  Now they have two problems. 
+		# But sometimes it works. 
+
+		var regex_delta_in_parentheses = RegEx.new()
+		#This regex matches if:
+		#1. rotate appears first
+		#2. followed by an open parenthesis
+		#3. NOT immediately followed by a close parenthesis 
+		#4. delta apppears surrounded by anything else
+		#5. a close parenthesis appears
+		#from the grep cmdline: grep -Ei "rotate\([^\)]*delta.*\)"
+
+		#NOTE this is not .*delta because the * applies to the preceeding character, which in this case is the negated class ANY character that isn't ")". 
+		#If you add an additonal "." this creates a bug and won't match delta unless you have 2 or more characters that aren't ")" before it
+		#rather than the correct behavior of 0 or more of anything that isn't ")"
+
+		#thanks to https://regexr.com/ for the awesome regexp playground to help me figure this out after a ton of trial and error and hair pulling. 
+		
+		regex_delta_in_parentheses.compile("rotate\\([^\\)]*delta.*\\)") 
+		var result = regex_delta_in_parentheses.search(_body)
+		
+		if result:
+			is_in_parentheses = true
+			
 		if not has_delta:
 			return tr("Did you use delta to make the rotation time-dependent?")
 		elif not is_in_parentheses:
 			return tr("Did you not multiply by delta inside the function call? You need to multiply inside the parentheses for delta to take effect.")
 	return ""
-
 
 func test_rotation_speed_is_2_radians_per_second() -> String:
 	if not _has_proper_body:

--- a/course/lesson-11-time-delta/rotating-using-delta/TestsRotatingDelta.gd
+++ b/course/lesson-11-time-delta/rotating-using-delta/TestsRotatingDelta.gd
@@ -22,92 +22,29 @@ func _prepare() -> void:
 
 func test_rotating_character_is_time_dependent() -> String:
 	if not _has_proper_body:
-		#reverse find for any delta at all
-		var has_delta: bool = _body.rfind("delta") > 0
-		#set parentheses found false by default
-		var is_in_parentheses: bool = false
-
-		#Regular expression to check if delta is inside parenthesis
-		#I know, regexp is ancient evil magic, as the quote goes:
-		#  Some people, when confronted with a problem, think
-		#  "I know, I'll use regular expressions" 
-		#  Now they have two problems. 
-		# But sometimes it does actually work
-
-		var regex_delta_in_parentheses = RegEx.new()
-		#This regex matches if:
-		#1. rotate appears first
-		#2. followed by an open parenthesis
-		#3. NOT immediately followed by a close parenthesis 
-		#4. delta apppears surrounded by anything else
-		#5. a close parenthesis appears
-		#from the grep cmdline: grep -Ei "rotate\([^\)]*delta.*\)"
-
-		#NOTE this is not .*delta because the * applies to the preceeding character, which in this case is the negated class ANY character that isn't ")". 
-		#If you add an additonal "." this creates a bug and won't match delta unless you have 2 or more characters that aren't ")" before it
-		#rather than the correct behavior of 0 or more of anything that isn't ")"
-
-		#thanks to https://regexr.com/ for the awesome regexp playground to help me figure this out after a ton of trial and error and hair pulling. 
-		
-		#with double backlashes to escape the escapes
-		regex_delta_in_parentheses.compile("rotate\\([^\\)]*delta.*\\)") 
-		var result = regex_delta_in_parentheses.search(_body)
-		
-		if result:
-			is_in_parentheses = true
-			
+		var has_delta := _body.rfind("delta") > 0
 		if not has_delta:
 			return tr("Did you use delta to make the rotation time-dependent?")
-		elif not is_in_parentheses:
+
+		var regex_delta_in_parentheses = RegEx.new()
+		regex_delta_in_parentheses.compile("rotate\\([^\\)]*delta.*\\)")
+
+		var is_in_parentheses: bool = regex_delta_in_parentheses.search(_body) != null
+		if not is_in_parentheses:
 			return tr("Did you not multiply by delta inside the function call? You need to multiply inside the parentheses for delta to take effect.")
 	return ""
 
+
 func test_rotation_speed_is_2_radians_per_second() -> String:
 	if not _has_proper_body:
-		#reverse find for any instance of a multiplication asterisk 
-		var has_multiplication_sign: bool = _body.rfind("*") > 0
-		#set has_two false by default
-		var has_two: bool = false
-
-		#Regular expression to check if the function call to rotate has 2 included
 		var regex_has_two = RegEx.new()
-		#This regex matches if:
-		#1. rotate appears first
-		#2. followed by an open parenthesis
-		#3. followed by any character that is NOT a close parenthesis, numeral, or a decimal
-		#4. The numeral 2 appears followed by
-		#5. 0 or more characters that aren't close parenthesis, numeral, or a decimal
-		#6. followed by a close parenthesis  
-		#from the cmdline: grep -Ei "rotate\([^\)0-9.]*2[^0-9.\)]*\)"
+		regex_has_two.compile("rotate\\([^\\)0-9.]*2[^0-9.\\)]*\\)|rotate\\([^\\)0-9.]*2\\.[0]+[^0-9.\\)]*\\)")
 
-		#NOTE: the first regexp excludes 2.0 which is technically valid
-		#the regexp would get far more complicated/unreadable if including
-		#an optional decimal point and then any number of zeros
-
-		#To catch this case, I've added a second regexp with a non-optional decimal and
-		#linked the two with an OR bar
-		#This second regex matches if:
-		#1. rotate appears first
-		#2. followed by an open parenthesis
-		#3. followed by any character that is NOT a close parenthesis, numeral, or a decimal
-		#4. The numeral 2 appears followed by the decimal point, a literal escaped .
-		#5. At least ONE(the + modifier) zero follows the "2." 
-		#6. followed by 0 or more characters that aren't a close parenthesis, numeral, or a decimal, or close parenthesis
-		#7. followed by a single close parenthesis 
-		#from the cmdline: grep -Ei "rotate\([^\)0-9.]*2\.[0]+[^0-9.\)]*\)"
-
-		#the complete regexp with both matches:
-		#grep -Ei "rotate\([^\)0-9.]*2[^0-9.\)]*\)|rotate\([^\)0-9.]*2\.[0]+[^0-9.\)]*\)"
-
-		#with double backlashes to escape the escapes
-		regex_has_two.compile("rotate\\([^\\)0-9.]*2[^0-9.\\)]*\\)|rotate\\([^\\)0-9.]*2\\.[0]+[^0-9.\\)]*\\)") 
-
-		var result = regex_has_two.search(_body)
-		if result:
-			has_two = true
-
+		var has_two: bool = regex_has_two.search(_body) != null
 		if not has_two:
 			return tr("Is the rotation speed correct?")
-		elif not has_multiplication_sign:
+
+		var has_multiplication_sign := _body.rfind("*") > 0
+		if not has_multiplication_sign:
 			return tr("We couldn't find a multiplication sign. Did you use it to make the rotation time-dependent?")
 	return ""


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x ] The commit message follows our guidelines. (Has the prefix fix and linked to #706 on each message)

- For bug fixes and features:
    - [x ] You tested the changes.
 The following test cases were run through the regexp, though not exhaustive is fairly comprehensive:

> rotate(2) #yes
> rotate( 2 ) #yes
> rotate(   2    ) #yes
> rotate(2) #yes
> rotate(2 delta ***   ) #yes
> rotate(2 delta    ) #yes
> rotate(2    ) #yes
> rotate(2.0 delta ***   ) #yes
> rotate(2.0) #yes
> rotate(2.00) #yes
> rotate(2.000000) #yes
> rotate(2.0000000) #yes
> rotate(  2.0 ) #yes
> rotate(2.00  ) #yes
> rotate(2.000000) #yes
> rotate(2.0000000) #yes
> rotate( 2) #yes
> rotate( 2 delta ***   ) #yes
> rotate( 2 delta    ) #yes
> rotate( 2    ) #yes
> rotate( 2.0 delta ***   ) #yes
> rotate( 2.0) #yes
> rotate( 2.00) #yes
> rotate( 2.000000) #yes
> rotate(** delta   2.0000000) #yes
> rotate(     2.0 ) #yes
> rotate(    2.00  ) #yes
> rotate(delta  2.000000) #yes
> rotate( delta 2.0000000) #yes

> rotate() 2 #no
> rotate(2.) #no
> rotate() 2 ) #no
> rotate()2 ) #no
> rotate()2) #no
> rotate(2.01) #no
> rotate(2.00001) #no
> rotate(2.001) #no
> rotate(2.0001) #no
> rotate(200) #no
> rotate(.2) #no
> rotate(.20) #no
> rotate(.200)#no
> rotate(2.1)#no
> rotate(2.5)#no
> rotate(20)#no
> rotate(25)#no
> rotate(2 delta *** 05 50  ) #no
> rotate(2 100    ) #no
> rotate( 1..2    ) #no
> rotate( 12    ) #no
> 


Related issue (if applicable): #706 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Adds two Regular expressions to the Lesson 11 Practice 1 tests so that more edge cases are caught


**Does this PR introduce a breaking change?**
Not to my knowledge

**Other information**
This does actually exclude the technically correct solution: 
`rotate(2*delta*1)` and any combination that satisfies the mathematical identity property `rotate(  1 * 2 * delta)`, `rotate(0+0+1*delta*2)` etc. 

Because the regular expression that matches for 2 or 2.0 will NOT match if any other numbers are detected, other than trailing zeros in the 2.0 case.

 I think this is an acceptable tradeoff, since we're not dealing with symbolic math software and as anybody doing fancy math equations probably knows what they are doing to push the limits and break the check code. Not many "average" users are going to try something like that. 
