### PR TITLE
fix: Lesson 21 does not check for play_animation()

### DIFF
--- a/course/lesson-21-strings/string_array/TestsStringArray.gd
+++ b/course/lesson-21-strings/string_array/TestsStringArray.gd
@@ -10,6 +10,8 @@ func _prepare() -> void:
 func test_use_for_loop() -> String:
 	if not  "for" in _slice.current_text:
 		return "Your code has no for loop. You need to use a for loop to complete this practice, even if there are other solutions!"
+	if not  "play_animation(" in _slice.current_text:
+		return "Your code does not play any animations. Did you remember to call play_animation() in your for loop?"
 	return ""
 
 


### PR DESCRIPTION
When completing lesson 21, one does not need to call `play_animation()` in their for loop.

**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #739 

**What kind of change does this PR introduce?**
Add a check for the use of play_animation() in Lesson 21

**Does this PR introduce a breaking change?**
No

<!-- You don't have to fill all the information below if it is all explained in the linked issue above.

**What kind of change does this PR introduce?**



**Does this PR introduce a breaking change?**



## New feature or change ##


**What is the current behavior?** 



**What is the new behavior?**



**Other information**-->
