### PR TITLE
fix: Lesson 21 - remove Step button from combo example

### DIFF
--- a/course/lesson-21-strings/visuals/ExampleCombo.tscn
+++ b/course/lesson-21-strings/visuals/ExampleCombo.tscn
@@ -14,7 +14,7 @@ var combo = [\"jump\", \"damage\", \"damage\", \"jump\", \"level\"]
 
 func run():
 	# Running as a private method to avoid returning a \"GDScriptFunctionState\"
-	# to RunnableCodeExample after \"yield()\".
+	# to RunnableCodeExample after \"yield(...)\".
 	_run()
 
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [X] The commit message follows our guidelines.
- For bug fixes and features:
    - [X] You tested the changes.


Related issue (if applicable): #799 

**Other information**
I'm assuming the 'Step' button being added to the final example in Lesson 21 was an accident - the code that looks for `yield()` to determine whether or not to add the 'Step' button to the example was catching the `yield()` that was commented out.