### PR TITLE
content: fix starting_code for lesson 28

### DIFF
--- a/course/lesson-28-specifying-types/lesson.tres
+++ b/course/lesson-28-specifying-types/lesson.tres
@@ -293,7 +293,7 @@ Your task is to fix the values after the equal sign, so they match the type hint
 starting_code = "var whole_number: int = \"Hello, world!\"
 var text: String = 4
 var vector: Vector2 = 3.14
-var decimal_number: float = []"
+var decimal_number: float = Vector2(1, 1)"
 cursor_line = 0
 cursor_column = 0
 hints = PoolStringArray( "The type [code]float[/code] means decimal number, so you need to write a number with a decimal part, like [code]3.14[/code].", "The type [code]int[/code] stands for integer or whole number, so you need the value to be a whole number without a decimal part.", "The type [code]String[/code] means you need to write a text string, a value surrounded by quotes." )


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #844

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Changes [] to Vector2(1, 1) in the starting code for lesson 28.


**Does this PR introduce a breaking change?**
No

**What is the current behavior?** 
The starting code has [], but the tests check for Vector2(1, 1). And the solution uses Vector2(1, 1) as well.


**What is the new behavior?**
The starting code has Vector2(1, 1)
