### PR TITLE
improvement: adapt regex to search for the appropriate closing bracket

### DIFF
--- a/autoload/MessageBus.gd
+++ b/autoload/MessageBus.gd
@@ -18,7 +18,7 @@ var script_replacements := RegExpGroup.collection(
 	{
 		"\\b(?<command>prints)\\((?<args>.*?)\\)":
 		"MessageBus.print_log([{args}], \"{file}\", {line}, {char})",
-		"\\b(?<command>print)\\((?<args>.*?)\\)":
+		"\\b(?<command>print)\\((?<args>[^()]*(?:\\([^()]*\\))?[^()]*)\\)":
 		"MessageBus.print_log([{args}], \"{file}\", {line}, {char})",
 		"\\b(?<command>push_error)\\((?<args>.*?)\\)":
 		"MessageBus.print_error({args}, \"{file}\", {line}, {char})",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #979 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**



**Does this PR introduce a breaking change?**



## New feature or change ##


**What is the current behavior?** 
see https://github.com/GDQuest/learn-gdscript/issues/979

The generated Script will look like:

```
extends Node2D

onready var _animation_tree := find_node("AnimationTree")

func _ready():
	var i = 0
	MessageBus.print_log([str(i], "WelcomeToTheApp", 6, 1))
	yield(get_tree().create_timer(1.0), "timeout")
	Events.emit_signal("practice_run_completed")

func _run():
	_animation_tree.travel("saying_hi")
```

and due to `[str(i]` it will crash.


**What is the new behavior?**

adapt the regex to search for the appropriate closing bracket

![image](https://github.com/user-attachments/assets/6c8ea18f-eb56-4cdf-965d-68775c3ea440)



**Other information**
