### PR TITLE
fix: __guard_counter already defined in the scope

### DIFF
--- a/ui/UIPractice.gd
+++ b/ui/UIPractice.gd
@@ -306,7 +306,7 @@ func _validate_and_run_student_code() -> void:
 	# Guard against infinite while loops
 	if "while " in script_text:
 		var modified_code := PoolStringArray()
-		var guard_counter_defined = false
+		var guard_counter = 0
 		for line in script_text.split("\n"):
 			if "while " in line and not line.strip_edges(true, false).begins_with("#"):
 				var indent := 0
@@ -314,15 +314,13 @@ func _validate_and_run_student_code() -> void:
 					indent += 1
 
 				var tabs := "\t".repeat(indent)
-				if guard_counter_defined:
-					modified_code.append(tabs + "__guard_counter = 0")
-				else:
-					modified_code.append(tabs + "var __guard_counter := 0")
-					guard_counter_defined = true
+				var guard_counter_varname = "__guard_counter" + str(guard_counter) 
+				guard_counter += 1
+				modified_code.append(tabs + "var " + guard_counter_varname + " := 0")
 				modified_code.append(line)
-				modified_code.append(tabs + "\t" + "__guard_counter += 1")
+				modified_code.append(tabs + "\t" + guard_counter_varname + " += 1")
 				modified_code.append(
-					tabs + "\t" + "if __guard_counter > %s:" % MAX_WHILE_LOOP_ITERATIONS
+					tabs + "\t" + "if " + guard_counter_varname + " > %s:" % MAX_WHILE_LOOP_ITERATIONS
 				)
 				modified_code.append(tabs + "\t\t" + "break")
 			else:

--- a/ui/UIPractice.gd
+++ b/ui/UIPractice.gd
@@ -306,6 +306,7 @@ func _validate_and_run_student_code() -> void:
 	# Guard against infinite while loops
 	if "while " in script_text:
 		var modified_code := PoolStringArray()
+		var guard_counter_defined = false
 		for line in script_text.split("\n"):
 			if "while " in line and not line.strip_edges(true, false).begins_with("#"):
 				var indent := 0
@@ -313,7 +314,11 @@ func _validate_and_run_student_code() -> void:
 					indent += 1
 
 				var tabs := "\t".repeat(indent)
-				modified_code.append(tabs + "var __guard_counter := 0")
+				if guard_counter_defined:
+					modified_code.append(tabs + "__guard_counter = 0")
+				else:
+					modified_code.append(tabs + "var __guard_counter := 0")
+					guard_counter_defined = true
 				modified_code.append(line)
 				modified_code.append(tabs + "\t" + "__guard_counter += 1")
 				modified_code.append(


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #961


## New feature or change ##


**What is the current behavior?** 
Currently the app will crash if you have more then one `while` loop in the `script_text` due to:

![image](https://github.com/user-attachments/assets/da4526a0-0e49-40e9-be5b-2814f308091e)

The generate code (`script_text`) looked like this:

```
func move_to_bottom():
	var __guard_counter := 0
	while cell.x < board_size.x - 1:
		__guard_counter += 1
		if __guard_counter > 100:
			break
		cell.x += 1
	var __guard_counter := 0
	while cell.y < board_size.y -1:
		__guard_counter += 1
		if __guard_counter > 100:
			break
		cell.y += 1
```


**What is the new behavior?**
Change will define the variable `__guard_counter` just once and for other while loops it will be set back to 0.

Now the code looks like:

```
func move_to_bottom():
	var __guard_counter := 0
	while cell.x < board_size.x - 1:
		__guard_counter += 1
		if __guard_counter > 100:
			break
		cell.x += 1
	__guard_counter = 0
	while cell.y < board_size.y -1:
		__guard_counter += 1
		if __guard_counter > 100:
			break
		cell.y += 1
```


**Other information**
