### PR TITLE
#622 error in 13. conditions limited healing

### DIFF
--- a/course/lesson-13-conditions/limiting_health/TestLimitingHealth.gd
+++ b/course/lesson-13-conditions/limiting_health/TestLimitingHealth.gd
@@ -22,6 +22,10 @@ func test_health_limit_is_not_too_low() -> String:
 	return ""
 
 func test_health_takes_different_values() -> String:
-	if first_node.get_produced_health_values() != _expected_health_values:
+	var produced_health_values = first_node.get_produced_health_values() 
+
+	for i in range(produced_health_values.size()):
+		if produced_health_values[i] != _expected_health_values[i]:
 		return tr("When healing the character twice by 40 points, the health should go up to 60, then 80. Instead, we got %s.\nAre you using the amount parameter?") % [first_node.get_produced_health_values()]
+			
 	return ""

--- a/course/lesson-13-conditions/limiting_health/TestLimitingHealth.gd
+++ b/course/lesson-13-conditions/limiting_health/TestLimitingHealth.gd
@@ -1,7 +1,7 @@
 extends PracticeTester
 
 var first_node: Control
-var health := 0
+var health := 0.0
 
 var _expected_health_values = [60, 80]
 
@@ -26,6 +26,6 @@ func test_health_takes_different_values() -> String:
 
 	for i in range(produced_health_values.size()):
 		if produced_health_values[i] != _expected_health_values[i]:
-		return tr("When healing the character twice by 40 points, the health should go up to 60, then 80. Instead, we got %s.\nAre you using the amount parameter?") % [first_node.get_produced_health_values()]
+			return tr("When healing the character twice by 40 points, the health should go up to 60, then 80. Instead, we got %s.\nAre you using the amount parameter?") % [first_node.get_produced_health_values()]
 			
 	return ""


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #622 


## New feature or change ##


**What is the current behavior?** 
Currently the test "Health Takes Different Values" will fail with missleading message when an floatingpoint value is used for `health`

Also the test "Health Does Not Go Above 80" will wrongly pass when an floatingpoint values between 80.1 and 80.9 is set:


**What is the new behavior?**

The test "Health Takes Different Values" will pass correctly even if "80" or "80.0" is set for `health`
![image](https://github.com/user-attachments/assets/cc6efd7c-a9ed-4a78-987c-284b9f7653fe)


Also test "Health Does Not Go Above 80" will fail correctly

![image](https://github.com/user-attachments/assets/3a58fb7c-6426-4fbd-94d7-97611d7b2212)




**Other information**
