### PR TITLE
10. Fix "frame" word

### DIFF
--- a/i18n/ru/lesson-10-the-game-loop.po
+++ b/i18n/ru/lesson-10-the-game-loop.po
@@ -135,7 +135,7 @@ msgstr ""
 "[code]_process[/code], то Godot будет автоматически запускать её каждый "
 "[i]кадр[/i]. \n"
 "\n"
-"Когда Godot рисует на экране, мы называем это рамкой."
+"Когда Godot рисует на экране, мы называем это кадром."
 
 #: course/lesson-10-the-game-loop/lesson.tres:92
 msgid "Is this the same for other engines?"


### PR DESCRIPTION
- [x] The commit message follows our guidelines.


**What kind of change does this PR introduce?**
In Russian translation of chapter 10, frames are called "рамки", but "рамки" means frames for art or something like that. Most russian gamers call these "кадры" и "кадры в секунду" ("frames" and "frames per second" respectively). It's also inconsistent, because the sentence above that has frames called "кадры" already.
![image](https://github.com/user-attachments/assets/fe78cfa4-81b0-4b09-b9f3-66048bdcf3fe)


**Does this PR introduce a breaking change?**
No, it's just to reduce confusion
