### PR TITLE
tests: strict regex for delta multiplication to prevent extra factors

### DIFF
--- a/course/lesson-11-time-delta/rotating-and-moving-delta/TestsRotatingMovingDelta.gd
+++ b/course/lesson-11-time-delta/rotating-and-moving-delta/TestsRotatingMovingDelta.gd
@@ -28,7 +28,7 @@ func test_moving_in_a_circle() -> String:
 #			return tr(
 #				"It seems that you called move_local_x() with two arguments but you should only use one. Did you add a comma between values? You need to multipy them instead."
 #			)
-
+	
 	if not has_rotate:
 		return tr("Did you use rotate() to make the sprite rotate?")
 	elif not has_move_local:
@@ -50,10 +50,12 @@ func test_movement_is_time_dependent() -> String:
 
 
 func test_movement_speed_is_correct() -> String:
-	var has_correct_rotation := matches_code_line(["rotate(delta*2*)", "rotate(2*delta)"])
-	var has_correct_speed := matches_code_line(
-		["move_local_x(100*delta*)", "move_local_x(delta*100*)"]
-	)
+	var has_correct_rotation := matches_code_line_regex([
+		"rotate\\s*\\(\\s*(?:2(?:\\.0+)?\\s*\\*\\s*delta|delta\\s*\\*\\s*2(?:\\.0+)?)\\s*\\)"
+	])
+	var has_correct_speed := matches_code_line_regex([
+		"move_local_x\\s*\\(\\s*(?:100(?:\\.0+)?\\s*\\*\\s*delta|delta\\s*\\*\\s*100(?:\\.0+)?)\\s*\\)"
+	])
 
 	if not has_correct_rotation:
 		return tr("Is the rotation speed correct?")

--- a/course/lesson-11-time-delta/rotating-using-delta/TestsRotatingDelta.gd
+++ b/course/lesson-11-time-delta/rotating-using-delta/TestsRotatingDelta.gd
@@ -37,8 +37,8 @@ func test_rotating_character_is_time_dependent() -> String:
 
 func test_rotation_speed_is_2_radians_per_second() -> String:
 	if not _has_proper_body:
-		var regex_has_two = RegEx.new()
-		regex_has_two.compile("rotate\\([^\\)0-9.]*2[^0-9.\\)]*\\)|rotate\\([^\\)0-9.]*2\\.[0]+[^0-9.\\)]*\\)")
+		var regex_has_two := RegEx.new()
+		regex_has_two.compile("rotate\\s*\\(\\s*(?:2(?:\\.0+)?\\s*\\*\\s*delta|delta\\s*\\*\\s*2(?:\\.0+)?)\\s*\\)")
 
 		var has_two: bool = regex_has_two.search(_body) != null
 		if not has_two:


### PR DESCRIPTION
Close https://github.com/GDQuest/learn-gdscript/issues/1045

The false positives were happening for any 2 * [OPERATIONS OR NUMBERS] * delta.
I modified the regex patterns to support checking for both 2 * delta and delta * 2 without any operations or numbers in the middle.