### PR TITLE
Fix: Fixed Lesson 20 error messages

### DIFF
--- a/game_demos/DrawingTurtle.gd
+++ b/game_demos/DrawingTurtle.gd
@@ -60,10 +60,16 @@ func move_forward(distance: float) -> void:
 	var new_point := previous_point + Vector2.RIGHT.rotated(deg2rad(turn_degrees)) * distance
 	new_point = new_point.snapped(Vector2.ONE)
 	_points.append(new_point)
-
+	var is_closed := false
+	if new_point in _points:
+		# consider the polygon closed if a coordinate is repeated.
+		is_closed = true
+	_points.append(new_point)
 	_temp_command_stack.append(
 		{command = "move_to", target = new_point + position + _current_offset}
 	)
+	if is_closed:
+		_close_polygon()
 
 
 func turn_right(angle_degrees: float) -> void:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [ y] The commit message follows our guidelines.
- For bug fixes and features:
    - [y ] You tested the changes.


Related issues (if applicable): #1126 #1114 #867 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Improvement of game_demos\DrawingTurtle.gd


**Does this PR introduce a breaking change?**
no


## New feature or change ##


**What is the current behavior?** 
When "jump" is not called in lesson 20 part 2, the error messages are incorrect. In demos\DrawingTurtle.gd, "jump" is the only way a polygon is closed, which is what leads to this error.
<img width="1263" height="682" alt="Screenshot from 2025-10-25 17-32-01" src="https://github.com/user-attachments/assets/a0fae16a-6d8b-4f7f-b136-bfe8fdb53257" />


**What is the new behavior?**
The feedback messages are now correct in this case. Polygons can now be closed in the move_forward function as well as the jump function. 


**Other information**
