### PR TITLE
Fix: fixed lesson 25 part 2 test logic

### DIFF
--- a/course/lesson-26-looping-over-dictionaries/place-units/TestPlaceUnits.gd
+++ b/course/lesson-26-looping-over-dictionaries/place-units/TestPlaceUnits.gd
@@ -12,8 +12,8 @@ func test_all_items_are_displayed():
 	var source: Dictionary = grid.get("units")
 	var dicts_match := displayed.has_all(source.keys())
 	if dicts_match:
-		for value in displayed.values():
-			if not source.values().has(value):
+		for key in displayed:
+			if displayed[key] != source[key]:
 				dicts_match = false
 				break
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [ x] The commit message follows our guidelines.
- For bug fixes and features:
    - [ x] You tested the changes.


Related issue (if applicable): #1100 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
bug fix


**Does this PR introduce a breaking change?**
no


## New feature or change ##


**What is the current behavior?** 
The test for completing Lesson 25 Part 2 has imprecise logic which allows you to succeed even if the inputted solution is clearly incorrect. 


**What is the new behavior?**
The logic has been adjusted to only accept a solution which matches the expected solution.
<img width="1914" height="1078" alt="all_robots_error_handled" src="https://github.com/user-attachments/assets/0d156d92-c1ed-4297-b2d2-5ec9aaad1b47" />


**Other information**
Issue #1100 describes two bugs. This fix only addresses the first bug and not the second one, which involves the screen not clearing as expected.