### PR TITLE
Fix: fixed lesson 22 part 1 check

### DIFF
--- a/course/lesson-23-append-to-arrays/clearing-meals/TestClearingMeals.gd
+++ b/course/lesson-23-append-to-arrays/clearing-meals/TestClearingMeals.gd
@@ -8,7 +8,7 @@ func _prepare() -> void:
 
 
 func test_used_pop_front() -> String:
-	if not "waiting_orders.pop_front()" in _slice.current_text:
+	if not "waiting_orders.pop_front" in _slice.current_text:
 		return tr("We found no call to the pop_front() function. Did you forget to call it?")
 	return ""
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x ] The commit message follows our guidelines.
- For bug fixes and features:
    - [x ] You tested the changes.


Related issue (if applicable): #1098 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

minor change related to issue #1098 that makes the check for the use of pop_front a little more lax in lesson 22 part 1

**Does this PR introduce a breaking change?**



## New feature or change ##


**What is the current behavior?** 



**What is the new behavior?**
notice the space between pop_front and (); this previously was giving an error
<img width="1911" height="1079" alt="l22part1_success" src="https://github.com/user-attachments/assets/36cded5a-ebba-47c3-a551-22c7a8043fb2" />



**Other information**
