### PR TITLE
Fix: fixed lesson 5 part 2 faulty check logic

### DIFF
--- a/course/lesson-5-your-first-function/TestsDrawingThreeSquares.gd
+++ b/course/lesson-5-your-first-function/TestsDrawingThreeSquares.gd
@@ -20,9 +20,11 @@ func test_draw_three_squares_of_200_pixels() -> String:
 		return tr("You only drew one square. You need to draw three.")
 	elif count < 3:
 		return tr("You need to draw three squares.")
-	elif count > 3:
-		if polygons.size() == 4 and not polygons.back().is_empty():
+	elif count == 4:
+		if not polygons.back().is_empty():
 			return tr("You drew more than three squares. You need to draw only three!")
+	elif count > 4:
+		return tr("You drew more than three squares. You need to draw only three!")
 
 	var index := 1
 	for p in polygons:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [ x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x ] You tested the changes.


Close #1078

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

bug fix

**Does this PR introduce a breaking change?**

no

## New feature or change ##


**What is the current behavior?** 

the check for drawing more than 4 squares in lesson 5 part 2 was unhandled. you could draw any number of squares above 4 and succeed the test, including infinite squares (as demonstrated in issue #1078)

**What is the new behavior?**
For anywhere from 4 to infinite squares, the test fails. It must be 3 squares.

<img width="1918" height="1079" alt="correct_error_msg_l5p2" src="https://github.com/user-attachments/assets/48b28e25-7265-4853-965d-d97b20b8f4c8" />

**Other information**
