### PR TITLE
adding word boundary to func highlighter regex

### DIFF
--- a/autoload/TextUtils.gd
+++ b/autoload/TextUtils.gd
@@ -46,7 +46,7 @@ func _init() -> void:
 	
 
 	_REGEXES["code"].compile("\\[code\\](.+?)\\[\\/code\\]")
-	_REGEXES["func"].compile("(?<func>func)")
+	_REGEXES["func"].compile("(?<func>\\bfunc\\b)")
 	_REGEXES["number"].compile("(?<number>-?\\d+(\\.\\d+)?)")
 	_REGEXES["string"].compile("(?<string>[\"'].+[\"'])")
 	_REGEXES["symbol"].compile("(?<symbol>[a-zA-Z][a-zA-Z0-9_]+|[a-zA-Z])")


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [X] The commit message follows our guidelines.
- For bug fixes and features:
    - [X] You tested the changes.


Related issue (if applicable): #1153 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Adds a word boundary to the `func` highlighter to prevent it from highlighting e.g. the first four letters of `function_name`


**Does this PR introduce a breaking change?**
no


## New feature or change ##
Change to `TextUtils.gd`

**What is the current behavior?** 
partial highlighting of formatted code that contains the substring "func" (see issue screenshot)


**What is the new behavior?**
only highlights the string "func" if it appears as a separate word 


**Other information**
