### PR TITLE
removing hanging [/code] tag from lesson 11 russian translation

### DIFF
--- a/i18n/ru/lesson-11-time-delta.po
+++ b/i18n/ru/lesson-11-time-delta.po
@@ -27,7 +27,7 @@ msgid ""
 "We've seen how we can use our character's [code]_process()[/code] function "
 "to make it move continuously."
 msgstr ""
-"[/code]Мы видели, как можно использовать функцию [code]_process()[/code] "
+"Мы видели, как можно использовать функцию [code]_process()[/code] "
 "нашего персонажа, чтобы заставить его двигаться непрерывно."
 
 #: course/lesson-11-time-delta/lesson.tres:34


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [X] The commit message follows our guidelines.
- For bug fixes and features:
    - [X] You tested the changes.


Related issue (if applicable): #1120

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Removes hanging `[/code]` tag from the beginning of the Russian text of Lesson 11 


**Does this PR introduce a breaking change?**
no


## New feature or change ##
change (text cleanup)

**What is the current behavior?** 
<img width="1792" height="1200" alt="Screenshot_2025-10-30_22-56-40" src="https://github.com/user-attachments/assets/2009d74e-6da3-4dd5-9cb9-547947e3e24e" />



**What is the new behavior?**
<img width="1830" height="1190" alt="Screenshot_2025-10-30_22-54-26" src="https://github.com/user-attachments/assets/4f5cb4e2-a3e6-4dc0-b801-bc8528969f71" />



**Other information**
