### PR TITLE
Install butler during CI preparation

### DIFF
--- a/run
+++ b/run
@@ -438,6 +438,10 @@ prepare_ci_software(){
 	echo "DEBIAN_FRONTEND=noninteractive TZ=UTC apt-get install -y nodejs"
 	DEBIAN_FRONTEND=noninteractive TZ=UTC apt-get install -y nodejs
   fi
+  echo "wget -O butler.zip https://broth.itch.zone/butler/linux-amd64/LATEST/archive/default"
+  wget -O butler.zip https://broth.itch.zone/butler/linux-amd64/LATEST/archive/default
+  echo "unzip butler.zip -d /usr/local/bin"
+  unzip butler.zip -d /usr/local/bin
   echo "✓ installed software"
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.

**What kind of change does this PR introduce?**

The github release actions failed due to lack of `butler` binary. Apparently this was included in the godot-ci image, but not build automation, and this got missed.

**Does this PR introduce a breaking change?**

No

## New feature or change ##


**What is the current behavior?** 

butler fails with command not found during workflow

**What is the new behavior?**

butler should launch during workflow
