### PR TITLE
Use debug templates for exports & prevent crashes in verification function

### DIFF
--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -13,8 +13,8 @@ script_encryption_key=""
 
 [preset.0.options]
 
-custom_template/debug="templates/godot.x11.opt.64"
-custom_template/release="templates/godot.x11.opt.64"
+custom_template/debug="templates/godot.x11.opt.debug.64"
+custom_template/release="templates/godot.x11.opt.debug.64"
 binary_format/architecture="x86_64"
 binary_format/embed_pck=false
 texture_format/bptc=false
@@ -38,8 +38,8 @@ script_encryption_key=""
 
 [preset.1.options]
 
-custom_template/debug="templates/godot.javascript.opt.zip"
-custom_template/release="templates/godot.javascript.opt.zip"
+custom_template/debug="templates/godot.javascript.opt.debug.zip"
+custom_template/release="templates/godot.javascript.opt.debug.zip"
 variant/export_type=0
 vram_texture_compression/for_desktop=true
 vram_texture_compression/for_mobile=false
@@ -73,8 +73,8 @@ script_encryption_key=""
 
 [preset.2.options]
 
-custom_template/debug="templates/godot.windows.opt.64.exe"
-custom_template/release="templates/godot.windows.opt.64.exe"
+custom_template/debug="templates/godot.windows.opt.debug.64.exe"
+custom_template/release="templates/godot.windows.opt.debug.64.exe"
 binary_format/64_bits=true
 binary_format/embed_pck=false
 texture_format/bptc=false

--- a/ui/UIPractice.gd
+++ b/ui/UIPractice.gd
@@ -722,11 +722,11 @@ static func try_validate_and_replace_script(node: Node, script: GDScript) -> voi
 
 	node.set_script(script)
 
-	parent.add_child(node)
+	parent.call_deferred("add_child", node)
 
 	if node.has_method("_run"):
 		# warning-ignore:unsafe_method_access
-		node._run()
+		node.call_deferred("_run")
 
 
 ###############################################################################


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


**What kind of change does this PR introduce?**

- Compile the templates as release_debug (https://github.com/Razoric480/custom-godot-builder has already been edited and re-published). This prevents user scripts that cause a runtime error from crashing the whole app.
  - However, just allowing runtime errors will result in the verifier hanging on the 'Verifying student code...' step without the second change.
- Defer adding the student script and calling its _run function so it happens outside of the verification function. This mimics the behaviour that happened in the previous release with the PracticeTester. This changes allows the `try_validate_and_replace_script` to finish without crashing even if there are (will be) runtime errors.

**Does this PR introduce a breaking change?**

No

## New feature or change ##


**What is the current behavior?** 

Do any lesson and replace the code with something like:

```gdscript
func _ready():
	var array = []
	array.append()
```

The app will crash when running.

**What is the new behavior?**

Do any lesson and replace the code with something like:

```gdscript
func _ready():
	var array = []
	array.append()
```

The app will run the code, even through the runtime errors, without crashing or hanging on verification.
