### PR TITLE
Fixed the typo of 'length' with 'size' as the correct argument

### DIFF
--- a/course/lesson-6-multiple-function-parameters/lesson.tres
+++ b/course/lesson-6-multiple-function-parameters/lesson.tres
@@ -139,7 +139,7 @@ title = ""
 type = 0
 text = "Parameters make your code easier to reuse. You write the function once as a template, then you can call it many times with different values.
 
-Here's an example with a function to draw any square. The parameter [code]length[/code] is a placeholder. Use the slider to change the value. When you click the button, the app calls [code]draw_square()[/code] and the placeholder gets replaced with your value, drawing squares of different sizes."
+Here's an example with a function to draw any square. The parameter [code]size[/code] is a placeholder. Use the slider to change the value. When you click the button, the app calls [code]draw_square()[/code] and the placeholder gets replaced with your value, drawing squares of different sizes."
 visual_element_path = ""
 reverse_blocks = false
 has_separator = false


### PR DESCRIPTION
- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [ ] You tested the changes.

Related issue (if applicable): #1224 


**What kind of change does this PR introduce?**
Replace the argument **length** with the correct one **size**.


**Does this PR introduce a breaking change?**
No


## New feature or change ##
No

**What is the current behavior?** 
<img width="476" height="155" alt="image" src="https://github.com/user-attachments/assets/023ce0a4-1e33-44c1-87d3-d5a559c18864" />



**What is the new behavior?**
Not available


**Other information**
No