### PR TITLE
L10, L11: Fix robot not being moved by move_local_x

### DIFF
--- a/course/lesson-10-the-game-loop/rotating-and-moving/RotateAndMoveSprite.gd
+++ b/course/lesson-10-the-game-loop/rotating-and-moving/RotateAndMoveSprite.gd
@@ -1,8 +1,10 @@
 extends Node2D
 
+onready var camera_2d := $Camera2D
 
 func _ready() -> void:
 	set_process(false)
+	camera_2d.set_as_toplevel(true)
 
 
 # EXPORT move_and_rotate

--- a/course/lesson-10-the-game-loop/rotating-and-moving/RotateAndMoveSprite.tscn
+++ b/course/lesson-10-the-game-loop/rotating-and-moving/RotateAndMoveSprite.tscn
@@ -4,9 +4,9 @@
 [ext_resource path="res://course/common/Robot.tscn" type="PackedScene" id=2]
 
 [node name="RotateAndMoveSprite" type="Node2D"]
+script = ExtResource( 1 )
 
 [node name="Robot" parent="." instance=ExtResource( 2 )]
-script = ExtResource( 1 )
 
 [node name="Camera2D" type="Camera2D" parent="."]
 current = true

--- a/course/lesson-11-time-delta/rotating-and-moving-delta/RotatingMovingSpriteDelta.gd
+++ b/course/lesson-11-time-delta/rotating-and-moving-delta/RotatingMovingSpriteDelta.gd
@@ -1,8 +1,10 @@
 extends Node2D
 
+onready var camera_2d := $Camera2D
 
 func _ready() -> void:
 	set_process(false)
+	camera_2d.set_as_toplevel(true)
 
 
 # EXPORT move_and_rotate

--- a/course/lesson-11-time-delta/rotating-and-moving-delta/RotatingMovingSpriteDelta.tscn
+++ b/course/lesson-11-time-delta/rotating-and-moving-delta/RotatingMovingSpriteDelta.tscn
@@ -1,23 +1,12 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://course/lesson-11-time-delta/rotating-and-moving-delta/RotatingMovingSpriteDelta.gd" type="Script" id=1]
 [ext_resource path="res://course/common/Robot.tscn" type="PackedScene" id=2]
 
-[sub_resource type="GDScript" id=1]
-script/source = "extends Node2D
-
-
-onready var _scene := $Robot
-
-func reset():
-	_scene.reset()
-"
-
 [node name="RotatingMovingSpriteDelta" type="Node2D"]
-script = SubResource( 1 )
+script = ExtResource( 1 )
 
 [node name="Robot" parent="." instance=ExtResource( 2 )]
-script = ExtResource( 1 )
 
 [node name="Camera2D" type="Camera2D" parent="."]
 current = true


### PR DESCRIPTION




Fixes https://github.com/GDQuest/learn-gdscript/issues/1228

**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #1228

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
A fix.


**Does this PR introduce a breaking change?**
No


## New feature or change ##


**What is the current behavior?** 

When running move_local_x the robot doesn't seem to move.


**What is the new behavior?**

When running move_local_x in the modified scenes of lessons 10 and 11, the robot will move.

**Other information**

This change is only local to those scenes, if a student tries move_local_x in other scenes/lessons the robot won't move if the scene is set up in the same way as these scenes previously were (Camera2D as child of root node).