### PR TITLE
L15.P2: :bug: lesson 16 exercise fix robot not updating in viewport 

### DIFF
--- a/course/lesson-16-2d-vectors/resetting_robot/RobotReset.gd
+++ b/course/lesson-16-2d-vectors/resetting_robot/RobotReset.gd
@@ -1,12 +1,15 @@
 extends Node2D
 
-# Lowers the chance of the student brute forcing using -/+
-var _position_start = Vector2(310.5413, 460.98476)
-var _scale_start = Vector2(5.154, 5.154)
+var _position_start: Vector2
+var _scale_start: Vector2
 
 onready var _animation_tree := find_node("AnimationTree")
+onready var _camera := $Camera2D
 
 func _ready() -> void:
+	_position_start = position
+	_scale_start = scale
+	_camera.set_as_toplevel(true)
 	reset()
 
 # EXPORT reset

--- a/course/lesson-16-2d-vectors/resetting_robot/RobotReset.tscn
+++ b/course/lesson-16-2d-vectors/resetting_robot/RobotReset.tscn
@@ -3,25 +3,15 @@
 [ext_resource path="res://course/lesson-16-2d-vectors/resetting_robot/RobotReset.gd" type="Script" id=1]
 [ext_resource path="res://course/common/Robot.tscn" type="PackedScene" id=2]
 
-[sub_resource type="GDScript" id=1]
-script/source = "extends Node2D
+[sub_resource type="AnimationNodeStateMachinePlayback" id=1]
 
-
-onready var _scene := $Robot
-
-# We create a reset() method here because UIPractice checks root node for
-# reset function.
-func reset():
-	_scene.reset()
-"
-
-[node name="RobotReset" type="Node2D"]
-script = SubResource( 1 )
-
-[node name="Robot" parent="." instance=ExtResource( 2 )]
-position = Vector2( 280, 480 )
-scale = Vector2( 6, 6 )
+[node name="RobotReset" instance=ExtResource( 2 )]
+position = Vector2( 310.5413, 460.98476 )
+scale = Vector2( 5.154, 5.154 )
 script = ExtResource( 1 )
 
-[node name="Camera2D" type="Camera2D" parent="."]
+[node name="AnimationTree" parent="." index="3"]
+parameters/playback = SubResource( 1 )
+
+[node name="Camera2D" type="Camera2D" parent="." index="4"]
 current = true

--- a/course/lesson-16-2d-vectors/resetting_robot/TestRobotReset.gd
+++ b/course/lesson-16-2d-vectors/resetting_robot/TestRobotReset.gd
@@ -4,7 +4,7 @@ var robot: Node2D
 
 
 func _prepare() -> void:
-	robot = _scene_root_viewport.get_child(0).get_child(1)
+	robot = _scene_root_viewport.get_child(0)
 
 
 func test_use_vector2_to_reset_robot() -> String:


### PR DESCRIPTION
closes #1235

**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Bug fix


**Does this PR introduce a breaking change?**
No


## New feature or change ##


**What is the current behavior?** 
Completing the resetting_robot exercise does not actually change the robot's position or size in the viewport. The student's `reset_robot()` runs without error, and the tests pass, but the robot never visibly moves or rescales.

The root cause is that `RobotReset.tscn` uses a wrapper `Node2D` as the scene root with `Robot` as a child. The practice system always attaches the student's script to the root node, so `reset_robot()` modifies the wrapper's position/scale — not the Robot's. The Camera2D is also a child of the wrapper, so it moves in lockstep, making the viewport appear unchanged.


**What is the new behavior?**
Robot now updates position and scale after running student code


**Other information**
- **`RobotReset.tscn`** — Removed the wrapper `Node2D` and restructured so `Robot` is the root node (instanced from `Robot.tscn` with `RobotReset.gd` as the script override), matching the pattern used by `IncreaseScale.tscn` and other exercises. The student's script now directly modifies the Robot.
- **`RobotReset.gd`** — Added `_camera.set_as_toplevel(true)` in `_ready()` so the Camera2D stays fixed at the origin while the robot starts at its offset position/scale. Without this, the camera would follow the robot as a child node, hiding the position offset the student needs to reset. This matches the pattern used in lessons 10 and 11.
- **`TestRobotReset.gd`** — Fixed `_prepare()` to reference `get_child(0)` (the Robot root) instead of `get_child(0).get_child(1)` (which was the Camera2D).