### PR TITLE
Fix typo in Portuguese translation label

### DIFF
--- a/autoload/TranslationManager.gd
+++ b/autoload/TranslationManager.gd
@@ -29,7 +29,7 @@ const LOCALE_TO_LABEL := {
 	"es": "Español",
 	"ja": "日本語",
 	"it": "Italiano",
-	"pt_BR": "Portugés",
+	"pt_BR": "Português",
 	"zh_Hans": "中文",
 	"ru": "русский",
 	"de": "Deutsch",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [ ] You tested the changes.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Bug fix

**Does this PR introduce a breaking change?**
No


## New feature or change ##
Corrects a typo in the Portuguese locale label for the language selector.

**What is the current behavior?** 
The Portuguese label was misspelled as Portugés.


**What is the new behavior?**
The Portuguese label is now correctly spelled as Português in `TranslationManager.gd` file.


**Other information**
Branch `fix-typo-portuguese` was created and the string was updated. No tests were run.