### PR TITLE
Create a GDScript AST analysis expression API

### DIFF
--- a/course/lesson-11-time-delta/rotating-and-moving-delta/TestsRotatingMovingDelta.gd
+++ b/course/lesson-11-time-delta/rotating-and-moving-delta/TestsRotatingMovingDelta.gd
@@ -51,39 +51,48 @@ func test_movement_is_time_dependent() -> String:
 
 
 func test_movement_speed_is_correct() -> String:
-	var used_vars := false
-	
 	var process := _analyzer.get_function_named("_process")
 	if not process:
-		return tr("The '_process(delta)' function is missing; did you remove it?")
+		return tr("The _process function is missing; did you remove it?")
 	
-	var process_delta_name := _analyzer.get_function_parameter_name(process, 0)
-	
-	var rotate_call := _analyzer.get_statement_call_named(process, "rotate")
-	if not rotate_call:
-		return tr("Did you use rotate() to make the sprite rotate?")
-	
-	if not GDExpr.function_call("rotate",
-			GDExpr.multiply(GDExpr.literal(2.0), GDExpr.identifier(process_delta_name))
-	).matches(rotate_call):
-		if GDExpr.function_call("rotate", GDExpr.identifier(".*?", true)).matches(rotate_call):
-			used_vars = true
-		else:
-			return tr("The rotation speed is not right. The robot should rotate 2 radians per second. Make sure the call looks like this: rotate(2 * delta).")
-	
-	var move_call := _analyzer.get_statement_call_named(process, "move_local_x")
-	if not move_call:
-		return tr("Did you use move_local_x() to make the sprite move locally?")
-	
-	if not GDExpr.function_call("move_local_x", GDExpr.multiply(GDExpr.literal(100.0), GDExpr.identifier(process_delta_name))).matches(move_call):
-		if GDExpr.function_call("move_local_x", GDExpr.identifier(".*?", true)).matches(rotate_call):
-			used_vars = true
-		else:
-			return tr("The movement speed is not right. The robot should move 100 pixels per second. Make sure the call looks like this: move_local_x(100 * delta).")
-	
-	if used_vars:
+	if GDExpr.suite(
+		GDExpr.any_of(
+			GDExpr.function_call(
+				"rotate",
+				GDExpr.any_identifier()
+			),
+			GDExpr.function_call(
+				"move_local_x",
+				GDExpr.any_identifier()
+			)
+		)
+	).matches(process):
 		return tr("It looks like you stored values in variables before passing them to the functions.") + " " + \
 				tr("That works in GDScript, but we cannot check the values automatically here.") + " " + \
 				tr("Please write the values directly inside the function calls, like this: rotate(2 * delta) and move_local_x(100 * delta).")
+	
+	var process_delta_name := _analyzer.get_function_parameter_name(process, 0)
+	
+	if not GDExpr.suite(
+		GDExpr.function_call(
+			"rotate",
+			GDExpr.multiply(
+				GDExpr.literal(2.0),
+				GDExpr.identifier(process_delta_name)
+			)
+		)
+	).matches(process):
+		return tr("The rotation speed is not right. The robot should rotate 2 radians per second. Make sure the call looks like this: rotate(2 * delta).")
+	
+	if not GDExpr.suite(
+		GDExpr.function_call(
+			"move_local_x",
+			GDExpr.multiply(
+				GDExpr.literal(100.0),
+				GDExpr.identifier(process_delta_name)
+			)
+		)
+	).matches(process):
+			return tr("The movement speed is not right. The robot should move 100 pixels per second. Make sure the call looks like this: move_local_x(100 * delta).")
 	
 	return ""

--- a/course/lesson-11-time-delta/rotating-and-moving-delta/TestsRotatingMovingDelta.gd
+++ b/course/lesson-11-time-delta/rotating-and-moving-delta/TestsRotatingMovingDelta.gd
@@ -44,29 +44,48 @@ func test_movement_is_time_dependent() -> String:
 
 
 func test_movement_speed_is_correct() -> String:
-	var has_correct_rotation := matches_code_line_regex(
-		["rotate\\s*\\(\\s*(?:2(?:\\.0+)?\\s*\\*\\s*delta|delta\\s*\\*\\s*2(?:\\.0+)?)\\s*\\)"],
-	)
-	var has_correct_speed := matches_code_line_regex(
-		["move_local_x\\s*\\(\\s*(?:100(?:\\.0+)?\\s*\\*\\s*delta|delta\\s*\\*\\s*100(?:\\.0+)?)\\s*(?:,\\s*(?:true|false)\\s*)?\\)"],
-	)
+	var checker := GDScriptErrorChecker.new()
+	checker.set_source(_slice.current_text)
+	var root := checker.get_root_parse_node()
+	
+	var used_vars := false
+	var has_correct_rotate := true
+	var has_correct_move := true
+	
+	var analyzer := GDScriptASTAnalyzer.new(root)
+	
+	var process := analyzer.get_function_named("_process")
+	if not process:
+		return tr("The '_process(delta)' function is missing; did you remove it?")
+	
+	var process_delta_name := analyzer.get_function_parameter_name(process, 0)
+	
+	var rotate_call := analyzer.get_statement_call_named(process, "rotate")
+	if not rotate_call:
+		return tr("Did you use rotate() to make the sprite rotate?")
+	
+	if analyzer.call_has_argument_identifier(rotate_call, 0):
+		used_vars = true
+	elif not analyzer.call_has_argument_x_operated_by_identifier(rotate_call, 0, GDBinaryOpNode.OP_MULTIPLICATION, process_delta_name, 2.0):
+		has_correct_rotate = false
 
-	if not has_correct_rotation or not has_correct_speed:
-		var var_regex := RegEx.new()
-		var_regex.compile("^var\\w*=")
-		var has_rotation_var := false
-		var has_speed_var := false
-		for line in _lines:
-			if not var_regex.search(line):
-				continue
-			has_rotation_var = has_rotation_var or (("2" in line or "2.0" in line) and "delta" in line)
-			has_speed_var = has_speed_var or (("100" in line or "100.0" in line) and "delta" in line)
-		if has_rotation_var or has_speed_var:
-			return tr("It looks like you stored values in variables before passing them to the functions.") + " " + \
-					tr("That works in GDScript, but we cannot check the values automatically here.") + " " + \
-					tr("Please write the values directly inside the function calls, like this: rotate(2 * delta) and move_local_x(100 * delta).")
-	if not has_correct_rotation:
-		return tr("The rotation speed is not right. The robot should rotate 2 radians per second. Make sure the call looks like this: rotate(2 * delta).")
-	elif not has_correct_speed:
+	var move_call := analyzer.get_statement_call_named(process, "move_local_x")
+	if not move_call:
+		return tr("Did you use move_local_x() to make the sprite move locally?")
+	
+	if analyzer.call_has_argument_identifier(move_call, 0):
+		used_vars = true
+	elif not analyzer.call_has_argument_x_operated_by_identifier(move_call, 0, GDBinaryOpNode.OP_MULTIPLICATION, process_delta_name, 100.0):
+		has_correct_move = false
+	
+	if used_vars:
+		return tr("It looks like you stored values in variables before passing them to the functions.") + " " + \
+				tr("That works in GDScript, but we cannot check the values automatically here.") + " " + \
+				tr("Please write the values directly inside the function calls, like this: rotate(2 * delta) and move_local_x(100 * delta).")
+	
+	if not has_correct_rotate:
 		return tr("The movement speed is not right. The robot should move 100 pixels per second. Make sure the call looks like this: move_local_x(100 * delta).")
+	if not has_correct_move:
+		return tr("The rotation speed is not right. The robot should rotate 2 radians per second. Make sure the call looks like this: rotate(2 * delta).")
+	
 	return ""

--- a/course/lesson-11-time-delta/rotating-and-moving-delta/TestsRotatingMovingDelta.gd
+++ b/course/lesson-11-time-delta/rotating-and-moving-delta/TestsRotatingMovingDelta.gd
@@ -98,5 +98,4 @@ func test_movement_speed_is_correct() -> String:
 		)
 	).matches(process):
 			return tr("The movement speed is not right. The robot should move 100 pixels per second. Make sure the call looks like this: move_local_x(100 * %s)." % [captures.delta])
-	
 	return ""

--- a/course/lesson-11-time-delta/rotating-and-moving-delta/TestsRotatingMovingDelta.gd
+++ b/course/lesson-11-time-delta/rotating-and-moving-delta/TestsRotatingMovingDelta.gd
@@ -2,11 +2,18 @@ extends PracticeTester
 
 var _robot: Node2D
 var _lines: PackedStringArray
+var _checker: GDScriptErrorChecker
+var _analyzer: GDScriptASTAnalyzer
 
 
 func _prepare() -> void:
 	_robot = _scene_root_viewport.get_child(0).get_node("Robot")
 	_lines = []
+	
+	_checker = GDScriptErrorChecker.new()
+	_checker.set_source(_slice.current_text)
+	var root := _checker.get_root_parse_node()
+	_analyzer = GDScriptASTAnalyzer.new(root)
 
 	var index := 0
 	for line in _slice.current_text.split("\n"):
@@ -44,48 +51,39 @@ func test_movement_is_time_dependent() -> String:
 
 
 func test_movement_speed_is_correct() -> String:
-	var checker := GDScriptErrorChecker.new()
-	checker.set_source(_slice.current_text)
-	var root := checker.get_root_parse_node()
-	
 	var used_vars := false
-	var has_correct_rotate := true
-	var has_correct_move := true
 	
-	var analyzer := GDScriptASTAnalyzer.new(root)
-	
-	var process := analyzer.get_function_named("_process")
+	var process := _analyzer.get_function_named("_process")
 	if not process:
 		return tr("The '_process(delta)' function is missing; did you remove it?")
 	
-	var process_delta_name := analyzer.get_function_parameter_name(process, 0)
+	var process_delta_name := _analyzer.get_function_parameter_name(process, 0)
 	
-	var rotate_call := analyzer.get_statement_call_named(process, "rotate")
+	var rotate_call := _analyzer.get_statement_call_named(process, "rotate")
 	if not rotate_call:
 		return tr("Did you use rotate() to make the sprite rotate?")
 	
-	if analyzer.call_has_argument_identifier(rotate_call, 0):
-		used_vars = true
-	elif not analyzer.call_has_argument_x_operated_by_identifier(rotate_call, 0, GDBinaryOpNode.OP_MULTIPLICATION, process_delta_name, 2.0):
-		has_correct_rotate = false
-
-	var move_call := analyzer.get_statement_call_named(process, "move_local_x")
+	if not GDExpr.function_call("rotate",
+			GDExpr.multiply(GDExpr.literal(2.0), GDExpr.identifier(process_delta_name))
+	).matches(rotate_call):
+		if GDExpr.function_call("rotate", GDExpr.identifier(".*?", true)).matches(rotate_call):
+			used_vars = true
+		else:
+			return tr("The rotation speed is not right. The robot should rotate 2 radians per second. Make sure the call looks like this: rotate(2 * delta).")
+	
+	var move_call := _analyzer.get_statement_call_named(process, "move_local_x")
 	if not move_call:
 		return tr("Did you use move_local_x() to make the sprite move locally?")
 	
-	if analyzer.call_has_argument_identifier(move_call, 0):
-		used_vars = true
-	elif not analyzer.call_has_argument_x_operated_by_identifier(move_call, 0, GDBinaryOpNode.OP_MULTIPLICATION, process_delta_name, 100.0):
-		has_correct_move = false
+	if not GDExpr.function_call("move_local_x", GDExpr.multiply(GDExpr.literal(100.0), GDExpr.identifier(process_delta_name))).matches(move_call):
+		if GDExpr.function_call("move_local_x", GDExpr.identifier(".*?", true)).matches(rotate_call):
+			used_vars = true
+		else:
+			return tr("The movement speed is not right. The robot should move 100 pixels per second. Make sure the call looks like this: move_local_x(100 * delta).")
 	
 	if used_vars:
 		return tr("It looks like you stored values in variables before passing them to the functions.") + " " + \
 				tr("That works in GDScript, but we cannot check the values automatically here.") + " " + \
 				tr("Please write the values directly inside the function calls, like this: rotate(2 * delta) and move_local_x(100 * delta).")
-	
-	if not has_correct_rotate:
-		return tr("The movement speed is not right. The robot should move 100 pixels per second. Make sure the call looks like this: move_local_x(100 * delta).")
-	if not has_correct_move:
-		return tr("The rotation speed is not right. The robot should rotate 2 radians per second. Make sure the call looks like this: rotate(2 * delta).")
 	
 	return ""

--- a/course/lesson-11-time-delta/rotating-and-moving-delta/TestsRotatingMovingDelta.gd
+++ b/course/lesson-11-time-delta/rotating-and-moving-delta/TestsRotatingMovingDelta.gd
@@ -2,18 +2,11 @@ extends PracticeTester
 
 var _robot: Node2D
 var _lines: PackedStringArray
-var _checker: GDScriptErrorChecker
-var _analyzer: GDScriptASTAnalyzer
 
 
 func _prepare() -> void:
 	_robot = _scene_root_viewport.get_child(0).get_node("Robot")
 	_lines = []
-	
-	_checker = GDScriptErrorChecker.new()
-	_checker.set_source(_slice.current_text)
-	var root := _checker.get_root_parse_node()
-	_analyzer = GDScriptASTAnalyzer.new(root)
 
 	var index := 0
 	for line in _slice.current_text.split("\n"):
@@ -71,28 +64,39 @@ func test_movement_speed_is_correct() -> String:
 				tr("That works in GDScript, but we cannot check the values automatically here.") + " " + \
 				tr("Please write the values directly inside the function calls, like this: rotate(2 * delta) and move_local_x(100 * delta).")
 	
-	var process_delta_name := _analyzer.get_function_parameter_name(process, 0)
-	
-	if not GDExpr.suite(
-		GDExpr.function_call(
-			"rotate",
-			GDExpr.multiply(
-				GDExpr.literal(2.0),
-				GDExpr.identifier(process_delta_name)
+	var captures := {}
+	if not GDExpr.function(
+		"_process",
+		GDExpr.suite(
+			GDExpr.function_call(
+				"rotate",
+				GDExpr.multiply(
+					GDExpr.literal(2.0),
+					GDExpr.captured_identifier("delta", captures)
+				)
 			)
+		),
+		GDExpr.parameter(
+			GDExpr.any_identifier().capture("delta", captures)
 		)
 	).matches(process):
-		return tr("The rotation speed is not right. The robot should rotate 2 radians per second. Make sure the call looks like this: rotate(2 * delta).")
+		return tr("The rotation speed is not right. The robot should rotate 2 radians per second. Make sure the call looks like this: rotate(2 * %s)." % [captures.delta])
 	
-	if not GDExpr.suite(
-		GDExpr.function_call(
-			"move_local_x",
-			GDExpr.multiply(
-				GDExpr.literal(100.0),
-				GDExpr.identifier(process_delta_name)
+	if not GDExpr.function(
+		"_process",
+		GDExpr.suite(
+			GDExpr.function_call(
+				"move_local_x",
+				GDExpr.multiply(
+					GDExpr.literal(100.0),
+					GDExpr.captured_identifier("delta", captures)
+				)
 			)
+		),
+		GDExpr.parameter(
+			GDExpr.any_identifier().capture("delta", captures)
 		)
 	).matches(process):
-			return tr("The movement speed is not right. The robot should move 100 pixels per second. Make sure the call looks like this: move_local_x(100 * delta).")
+			return tr("The movement speed is not right. The robot should move 100 pixels per second. Make sure the call looks like this: move_local_x(100 * %s)." % [captures.delta])
 	
 	return ""

--- a/course/lesson-11-time-delta/rotating-using-delta/TestsRotatingDelta.gd
+++ b/course/lesson-11-time-delta/rotating-using-delta/TestsRotatingDelta.gd
@@ -3,12 +3,19 @@ extends PracticeTester
 var _robot: Node2D
 var _body: String
 var _has_proper_body: bool
+var _checker: GDScriptErrorChecker
+var _analyzer: GDScriptASTAnalyzer
 
 
 func _prepare() -> void:
 	_robot = _scene_root_viewport.get_child(0).get_node("Robot")
 	_body = ""
 	_has_proper_body = true
+
+	_checker = GDScriptErrorChecker.new()
+	_checker.set_source(_slice.current_text)
+	var root := _checker.get_root_parse_node()
+	_analyzer = GDScriptASTAnalyzer.new(root)
 
 	for line in _slice.current_text.split("\n"):
 		line = line.strip_edges()
@@ -35,26 +42,27 @@ func test_rotating_character_is_time_dependent() -> String:
 
 
 func test_rotation_speed_is_2_radians_per_second() -> String:
-	if not _has_proper_body:
-		var regex_has_two := RegEx.new()
-		regex_has_two.compile("rotate\\s*\\(\\s*(?:2(?:\\.0+)?\\s*\\*\\s*delta|delta\\s*\\*\\s*2(?:\\.0+)?)\\s*\\)")
-
-		var has_two: bool = regex_has_two.search(_body) != null
-		if not has_two:
-			var var_regex := RegEx.new()
-			var_regex.compile("^var\\w*=")
-			var uses_variable := false
-			for line in _slice.current_text.split("\n"):
-				var stripped := line.strip_edges().replace(" ", "")
-				uses_variable = uses_variable or (var_regex.search(stripped) != null and ("2" in stripped or "2.0" in stripped) and "delta" in stripped)
-			if uses_variable:
-				return tr("It looks like you stored the value in a variable before using it.") + " " + \
-						tr("That's valid, but we can't check the value automatically.") + " " + \
-						tr("Please write it directly in the function call: rotate(2 * delta).")
-			return tr("The rotation speed is not right. The robot should rotate 2 radians per second. Make sure the call looks like this: rotate(2 * delta).")
-
-		var has_multiplication_sign := _body.rfind("*") > 0
-		if not has_multiplication_sign:
+	var process := _analyzer.get_function_named("_process")
+	if not process:
+		return tr("The '_process(delta)' function is missing; did you remove it?")
+	
+	var rotate_call := _analyzer.get_statement_call_named(process, "rotate")
+	if not rotate_call:
+		return tr("Did you use rotate() to make the sprite rotate?")
+	
+	var process_delta_name := _analyzer.get_function_parameter_name(process, 0)
+	
+	if not GDExpr.function_call("rotate",
+			GDExpr.multiply(GDExpr.literal(2.0), GDExpr.identifier(process_delta_name))
+	).matches(rotate_call):
+		if GDExpr.function_call("rotate", GDExpr.identifier(".*?", true)).matches(rotate_call):
+			return tr("It looks like you stored the value in a variable before using it.") + " " + \
+				tr("That's valid, but we can't check the value automatically.") + " " + \
+				tr("Please write it directly in the function call: rotate(2 * delta).")
+		elif GDExpr.function_call("rotate", GDExpr.literal(2.0)).matches(rotate_call):
 			return tr("It looks like delta is not being multiplied.") + \
 					tr("You need to use the * sign to multiply the speed by delta inside the parentheses, like this: rotate(2 * delta).")
+		else:
+			return tr("The rotation speed is not right. The robot should rotate 2 radians per second. Make sure the call looks like this: rotate(2 * delta).")
+	
 	return ""

--- a/course/lesson-11-time-delta/rotating-using-delta/TestsRotatingDelta.gd
+++ b/course/lesson-11-time-delta/rotating-using-delta/TestsRotatingDelta.gd
@@ -3,19 +3,12 @@ extends PracticeTester
 var _robot: Node2D
 var _body: String
 var _has_proper_body: bool
-var _checker: GDScriptErrorChecker
-var _analyzer: GDScriptASTAnalyzer
 
 
 func _prepare() -> void:
 	_robot = _scene_root_viewport.get_child(0).get_node("Robot")
 	_body = ""
 	_has_proper_body = true
-
-	_checker = GDScriptErrorChecker.new()
-	_checker.set_source(_slice.current_text)
-	var root := _checker.get_root_parse_node()
-	_analyzer = GDScriptASTAnalyzer.new(root)
 
 	for line in _slice.current_text.split("\n"):
 		line = line.strip_edges()

--- a/course/lesson-11-time-delta/rotating-using-delta/TestsRotatingDelta.gd
+++ b/course/lesson-11-time-delta/rotating-using-delta/TestsRotatingDelta.gd
@@ -44,25 +44,37 @@ func test_rotating_character_is_time_dependent() -> String:
 func test_rotation_speed_is_2_radians_per_second() -> String:
 	var process := _analyzer.get_function_named("_process")
 	if not process:
-		return tr("The '_process(delta)' function is missing; did you remove it?")
+		return tr("The _process function is missing; did you remove it?")
 	
-	var rotate_call := _analyzer.get_statement_call_named(process, "rotate")
-	if not rotate_call:
-		return tr("Did you use rotate() to make the sprite rotate?")
+	if GDExpr.suite(
+		GDExpr.function_call(
+			"rotate",
+			GDExpr.any_identifier()
+		)
+	).matches(process):
+		return tr("It looks like you stored the value in a variable before using it.") + " " + \
+				tr("That's valid, but we can't check the value automatically.") + " " + \
+				tr("Please write it directly in the function call: rotate(2 * delta).")
+	
+	if GDExpr.suite(
+		GDExpr.function_call(
+			"rotate",
+			GDExpr.literal(2.0)
+		)
+	).matches(process):
+		return tr("It looks like delta is not being multiplied.") + \
+				tr("You need to use the * sign to multiply the speed by delta inside the parentheses, like this: rotate(2 * delta).")
 	
 	var process_delta_name := _analyzer.get_function_parameter_name(process, 0)
 	
-	if not GDExpr.function_call("rotate",
-			GDExpr.multiply(GDExpr.literal(2.0), GDExpr.identifier(process_delta_name))
-	).matches(rotate_call):
-		if GDExpr.function_call("rotate", GDExpr.identifier(".*?", true)).matches(rotate_call):
-			return tr("It looks like you stored the value in a variable before using it.") + " " + \
-				tr("That's valid, but we can't check the value automatically.") + " " + \
-				tr("Please write it directly in the function call: rotate(2 * delta).")
-		elif GDExpr.function_call("rotate", GDExpr.literal(2.0)).matches(rotate_call):
-			return tr("It looks like delta is not being multiplied.") + \
-					tr("You need to use the * sign to multiply the speed by delta inside the parentheses, like this: rotate(2 * delta).")
-		else:
-			return tr("The rotation speed is not right. The robot should rotate 2 radians per second. Make sure the call looks like this: rotate(2 * delta).")
-	
+	if not GDExpr.suite(
+		GDExpr.function_call(
+			"rotate",
+			GDExpr.multiply(
+				GDExpr.literal(2.0),
+				GDExpr.identifier(process_delta_name)
+			)
+		)
+	).matches(process):
+		return tr("The rotation speed is not right. The robot should rotate 2 radians per second. Make sure the call looks like this: rotate(2 * delta).")
 	return ""

--- a/course/lesson-12-using-variables/clarify/TestClarifyCode.gd
+++ b/course/lesson-12-using-variables/clarify/TestClarifyCode.gd
@@ -39,11 +39,15 @@ func test_angular_speed_is_used_in_process_function() -> String:
 	if not process:
 		return tr("The '_process(delta)' function is missing; did you remove it?")
 	
-	var rotate_call := _analyzer.get_statement_call_named(process, "rotate")
-	if not rotate_call:
-		return tr("Did you use rotate() to make the sprite rotate?")
-	
-	if not GDExpr.function_call("rotate", GDExpr.multiply(GDExpr.identifier("angular_speed"), GDExpr.identifier("delta"))).matches(rotate_call):
+	if not GDExpr.suite(
+		GDExpr.function_call(
+			"rotate",
+			GDExpr.multiply(
+				GDExpr.identifier("angular_speed"),
+				GDExpr.identifier("delta")
+			)
+		)
+	).matches(process):
 		return tr("The rotate() call must multiply angular_speed by delta (e.g. rotate(angular_speed * delta)).")
 	
 	return ""

--- a/course/lesson-12-using-variables/clarify/TestClarifyCode.gd
+++ b/course/lesson-12-using-variables/clarify/TestClarifyCode.gd
@@ -2,8 +2,6 @@ extends PracticeTester
 
 var robot: Node2D
 var has_angular_speed_prop := false
-var _checker: GDScriptErrorChecker
-var _analyzer: GDScriptASTAnalyzer
 
 
 func _prepare():
@@ -13,10 +11,6 @@ func _prepare():
 		if property.name == "angular_speed":
 			has_angular_speed_prop = true
 			break
-	_checker = GDScriptErrorChecker.new()
-	_checker.set_source(_slice.current_text)
-	var root := _checker.get_root_parse_node()
-	_analyzer = GDScriptASTAnalyzer.new(root)
 
 
 func test_angular_speed_variable_is_script_wide() -> String:

--- a/course/lesson-12-using-variables/clarify/TestClarifyCode.gd
+++ b/course/lesson-12-using-variables/clarify/TestClarifyCode.gd
@@ -2,6 +2,8 @@ extends PracticeTester
 
 var robot: Node2D
 var has_angular_speed_prop := false
+var _checker: GDScriptErrorChecker
+var _analyzer: GDScriptASTAnalyzer
 
 
 func _prepare():
@@ -11,6 +13,10 @@ func _prepare():
 		if property.name == "angular_speed":
 			has_angular_speed_prop = true
 			break
+	_checker = GDScriptErrorChecker.new()
+	_checker.set_source(_slice.current_text)
+	var root := _checker.get_root_parse_node()
+	_analyzer = GDScriptASTAnalyzer.new(root)
 
 
 func test_angular_speed_variable_is_script_wide() -> String:
@@ -29,9 +35,15 @@ func test_angular_speed_has_value_of_4() -> String:
 
 
 func test_angular_speed_is_used_in_process_function() -> String:
-	var regex = RegEx.new()
-	regex.compile("rotate\\([^)]*(?:angular_speed\\s*\\*\\s*delta|delta\\s*\\*\\s*angular_speed)")
-	var result = regex.search(_slice.current_text)
-	if not result:
+	var process := _analyzer.get_function_named("_process")
+	if not process:
+		return tr("The '_process(delta)' function is missing; did you remove it?")
+	
+	var rotate_call := _analyzer.get_statement_call_named(process, "rotate")
+	if not rotate_call:
+		return tr("Did you use rotate() to make the sprite rotate?")
+	
+	if not GDExpr.function_call("rotate", GDExpr.multiply(GDExpr.identifier("angular_speed"), GDExpr.identifier("delta"))).matches(rotate_call):
 		return tr("The rotate() call must multiply angular_speed by delta (e.g. rotate(angular_speed * delta)).")
+	
 	return ""

--- a/course/lesson-12-using-variables/fixing_error/TestFixingError.gd
+++ b/course/lesson-12-using-variables/fixing_error/TestFixingError.gd
@@ -2,6 +2,8 @@ extends PracticeTester
 
 var robot: Node2D
 var has_angular_speed_prop := false
+var _checker: GDScriptErrorChecker
+var _analyzer: GDScriptASTAnalyzer
 
 
 func _prepare():
@@ -11,6 +13,10 @@ func _prepare():
 		if property.name == "angular_speed":
 			has_angular_speed_prop = true
 			break
+	_checker = GDScriptErrorChecker.new()
+	_checker.set_source(_slice.current_text)
+	var root := _checker.get_root_parse_node()
+	_analyzer = GDScriptASTAnalyzer.new(root)
 
 
 func test_has_angular_speed_variable() -> String:
@@ -29,27 +35,41 @@ func test_angular_speed_has_value_of_4() -> String:
 
 
 func test_angular_speed_is_used_in_process_function() -> String:
-	var regex = RegEx.new()
-	regex.compile("rotate\\([^)]*(?:angular_speed\\s*\\*\\s*delta|delta\\s*\\*\\s*angular_speed)")
-	var result = regex.search(_slice.current_text)
-	if not result:
+	var process := _analyzer.get_function_named("_process")
+	if not process:
+		return tr("The '_process(delta)' function is missing; did you remove it?")
+	
+	var rotate_call := _analyzer.get_statement_call_named(process, "rotate")
+	if not rotate_call:
+		return tr("Did you use rotate() to make the sprite rotate?")
+	
+	var process_delta_name := _analyzer.get_function_parameter_name(process, 0)
+	
+	if not GDExpr.function_call("rotate", GDExpr.multiply(GDExpr.identifier("angular_speed"), GDExpr.identifier(process_delta_name))).matches(rotate_call):
 		return tr("The rotate() call must multiply angular_speed by delta (e.g. rotate(angular_speed * delta)).")
+	
 	return ""
 
 
 func test_each_function_uses_the_same_variable() -> String:
-	var regex = RegEx.new()
-	regex.compile("var\\s*angular_speed")
-	var result = regex.search_all(_slice.current_text)
-	if result.size() > 1:
-		return "It looks like you declared angular_speed more than once. It should only be defined once."
+	var process := _analyzer.get_function_named("_process")
+	if not process:
+		return tr("The '_process(delta)' function is missing; did you remove it?")
+	
+	var local := _analyzer.get_local_var_named(process, "angular_speed")
+	if local:
+		return tr("It looks like you declared angular_speed more than once. It should only be defined once.")
 	return ""
 
 
 func test_angular_speed_is_used_in_setter_function() -> String:
-	var regex = RegEx.new()
-	regex.compile("\\)\\:\\s*angular_speed")
-	var result = regex.search(_slice.current_text)
-	if not result:
-		return "The set_angular_speed() function doesn't seem to use the angular_speed variable."
+	var setter := _analyzer.get_function_named("set_angular_speed")
+	if not setter:
+		return tr("The 'set_angular_speed(new_angular_speed)' function is missing; did you remove it?")
+	
+	var assignment_call := _analyzer.get_statement_assignment(setter, "angular_speed")
+	
+	if not assignment_call or not GDExpr.assignment(GDExpr.identifier("angular_speed"), GDExpr.identifier("new_angular_speed")).matches(assignment_call):
+		return tr("The set_angular_speed() function doesn't seem to use the angular_speed variable.")
+	
 	return ""

--- a/course/lesson-12-using-variables/fixing_error/TestFixingError.gd
+++ b/course/lesson-12-using-variables/fixing_error/TestFixingError.gd
@@ -2,8 +2,6 @@ extends PracticeTester
 
 var robot: Node2D
 var has_angular_speed_prop := false
-var _checker: GDScriptErrorChecker
-var _analyzer: GDScriptASTAnalyzer
 
 
 func _prepare():
@@ -13,10 +11,6 @@ func _prepare():
 		if property.name == "angular_speed":
 			has_angular_speed_prop = true
 			break
-	_checker = GDScriptErrorChecker.new()
-	_checker.set_source(_slice.current_text)
-	var root := _checker.get_root_parse_node()
-	_analyzer = GDScriptASTAnalyzer.new(root)
 
 
 func test_has_angular_speed_variable() -> String:

--- a/course/lesson-12-using-variables/fixing_error/TestFixingError.gd
+++ b/course/lesson-12-using-variables/fixing_error/TestFixingError.gd
@@ -67,9 +67,12 @@ func test_angular_speed_is_used_in_setter_function() -> String:
 	if not setter:
 		return tr("The 'set_angular_speed(new_angular_speed)' function is missing; did you remove it?")
 	
-	var assignment_call := _analyzer.get_statement_assignment(setter, "angular_speed")
-	
-	if not assignment_call or not GDExpr.assignment(GDExpr.identifier("angular_speed"), GDExpr.identifier("new_angular_speed")).matches(assignment_call):
+	if not GDExpr.suite(
+		GDExpr.assignment(
+			GDExpr.identifier("angular_speed"),
+			GDExpr.identifier("new_angular_speed")
+		)
+	).matches(setter):
 		return tr("The set_angular_speed() function doesn't seem to use the angular_speed variable.")
 	
 	return ""

--- a/course/lesson-13-conditions/using_conditions/TestUsingConditions.gd
+++ b/course/lesson-13-conditions/using_conditions/TestUsingConditions.gd
@@ -1,50 +1,76 @@
 extends PracticeTester
 
-var ANSWERS = [
-	"health\\s*>\\s*5",
-	"1\\s*<\\s*health",
-	"health\\s*==\\s*health",
-	"health\\s*!=\\s*7"
-]
 
-const STATEMENTS = [
-	"health is greater than five.",
-	"One is less than health.",
-	"health is equal to health",
-	"health is not equal to seven."
-]
+var _checker: GDScriptErrorChecker
+var _analyzer: GDScriptASTAnalyzer
+
+
+func _prepare() -> void:
+	_checker = GDScriptErrorChecker.new()
+	_checker.set_source(_slice.current_text)
+	var root := _checker.get_root_parse_node()
+	_analyzer = GDScriptASTAnalyzer.new(root)
+
 
 func test_statement_1_is_true() -> String:
-	var regex = RegEx.new()
-	regex.compile(ANSWERS[0] + "\\s*\\:\\s*.*" + STATEMENTS[0])
-	var result = regex.search(_slice.current_text)
-	if not result:
+	var run_function := _analyzer.get_function_named("run")
+	
+	if not GDExpr.suite(
+		GDExpr.if_block(
+			GDExpr.bin_op(
+				GDExpr.identifier("health"),
+				GDExpr.literal(5),
+				GDBinaryOpNode.OP_COMP_GREATER
+			)
+		)
+	).matches(run_function):
 		return tr("The first comparison is not correct. Did you use the right comparison?")
 	return ""
 
 
 func test_statement_2_is_true() -> String:
-	var regex = RegEx.new()
-	regex.compile(ANSWERS[1] + "\\s*\\:\\s*.*" + STATEMENTS[1])
-	var result = regex.search(_slice.current_text)
-	if not result:
+	var run_function := _analyzer.get_function_named("run")
+	
+	if not GDExpr.suite(
+		GDExpr.if_block(
+			GDExpr.bin_op(
+				GDExpr.literal(1),
+				GDExpr.identifier("health"), 
+				GDBinaryOpNode.OP_COMP_LESS
+			)
+		)
+	).matches(run_function):
 		return tr("The second comparison is not correct. Did you use the right comparison?")
 	return ""
 
 
 func test_statement_3_is_true() -> String:
-	var regex = RegEx.new()
-	regex.compile(ANSWERS[2] + "\\s*\\:\\s*.*" + STATEMENTS[2])
-	var result = regex.search(_slice.current_text)
-	if not result:
+	var run_function := _analyzer.get_function_named("run")
+	
+	if not GDExpr.suite(
+		GDExpr.if_block(
+			GDExpr.bin_op(
+				GDExpr.identifier("health"),
+				 GDExpr.identifier("health"),
+				 GDBinaryOpNode.OP_COMP_EQUAL
+			)
+		)
+	).matches(run_function):
 		return tr("The third comparison is not correct. Did you use the right comparison?")
 	return ""
 
 
 func test_statement_4_is_true() -> String:
-	var regex = RegEx.new()
-	regex.compile(ANSWERS[3] + "\\s*\\:\\s*.*" + STATEMENTS[3])
-	var result = regex.search(_slice.current_text)
-	if not result:
+	var run_function := _analyzer.get_function_named("run")
+	
+	if not GDExpr.suite(
+		GDExpr.if_block(
+			GDExpr.bin_op(
+				GDExpr.identifier("health"),
+				GDExpr.literal(7),
+				GDBinaryOpNode.OP_COMP_NOT_EQUAL
+			)
+		)
+	).matches(run_function):
 		return tr("The fourth comparison is not correct. Did you use the right comparison?")
 	return ""

--- a/course/lesson-13-conditions/using_conditions/TestUsingConditions.gd
+++ b/course/lesson-13-conditions/using_conditions/TestUsingConditions.gd
@@ -1,17 +1,6 @@
 extends PracticeTester
 
 
-var _checker: GDScriptErrorChecker
-var _analyzer: GDScriptASTAnalyzer
-
-
-func _prepare() -> void:
-	_checker = GDScriptErrorChecker.new()
-	_checker.set_source(_slice.current_text)
-	var root := _checker.get_root_parse_node()
-	_analyzer = GDScriptASTAnalyzer.new(root)
-
-
 func test_statement_1_is_true() -> String:
 	var run_function := _analyzer.get_function_named("run")
 	

--- a/course/lesson-14-multiplying/increase_max_health/TestHealthIncreased.gd
+++ b/course/lesson-14-multiplying/increase_max_health/TestHealthIncreased.gd
@@ -18,24 +18,29 @@ func _prepare():
 func test_addition_is_used_to_increase_level() -> String:
 	var level_up_function := _analyzer.get_function_named("level_up")
 	
-	if (
-		# level += 1
-		not GDExpr.suite(GDExpr.assignment(GDExpr.identifier("level"), GDExpr.literal(1), GDAssignmentNode.Operation.OP_ADDITION)).matches(level_up_function) and
-		# level = level + 1
-		not GDExpr.suite(GDExpr.assignment(GDExpr.identifier("level"), GDExpr.bin_op(GDExpr.identifier("level"), GDExpr.literal(1), GDBinaryOpNode.OpType.OP_ADDITION, false))).matches(level_up_function)
-	):
+	if not GDExpr.suite(
+		GDExpr.any_of(
+			# level += 1
+			GDExpr.assignment(GDExpr.identifier("level"), GDExpr.literal(1), GDAssignmentNode.Operation.OP_ADDITION),
+			# level = level + 1
+			GDExpr.assignment(GDExpr.identifier("level"), GDExpr.bin_op(GDExpr.identifier("level"), GDExpr.literal(1), GDBinaryOpNode.OpType.OP_ADDITION, false))
+		)
+	).matches(level_up_function):
 		return tr("It looks like level isn't increasing every level. Did you add 1 to it?")
+	
 	return ""
 
 
 func test_multiplication_is_used_to_increase_max_health() -> String:
 	var level_up_function := _analyzer.get_function_named("level_up")
 	
-	if (
-		# max_health *= 1.1
-		not GDExpr.suite(GDExpr.assignment(GDExpr.identifier("max_health"), GDExpr.literal(1.1), GDAssignmentNode.Operation.OP_MULTIPLICATION)).matches(level_up_function) and
-		# max_health = max_health * 1.1
-		not GDExpr.suite(GDExpr.assignment(GDExpr.identifier("max_health"), GDExpr.multiply(GDExpr.identifier("max_health"), GDExpr.literal(1.1)))).matches(level_up_function)
+	if not GDExpr.suite(
+		GDExpr.any_of(
+			# max_health *= 1.1
+			not GDExpr.suite(GDExpr.assignment(GDExpr.identifier("max_health"), GDExpr.literal(1.1), GDAssignmentNode.Operation.OP_MULTIPLICATION)).matches(level_up_function),
+			# max_health = max_health * 1.1
+			not GDExpr.suite(GDExpr.assignment(GDExpr.identifier("max_health"), GDExpr.multiply(GDExpr.identifier("max_health"), GDExpr.literal(1.1)))).matches(level_up_function)
+		)
 	):
 		tr("It looks like max_health isn't increasing exponentially. Did you multiply it by a value greater than 1?")
 	return ""

--- a/course/lesson-14-multiplying/increase_max_health/TestHealthIncreased.gd
+++ b/course/lesson-14-multiplying/increase_max_health/TestHealthIncreased.gd
@@ -2,17 +2,9 @@ extends PracticeTester
 
 var first_node: Node2D
 
-var _checker: GDScriptErrorChecker
-var _analyzer: GDScriptASTAnalyzer
-
 
 func _prepare():
 	first_node = _scene_root_viewport.get_child(0)
-	
-	_checker = GDScriptErrorChecker.new()
-	_checker.set_source(_slice.current_text)
-	var root := _checker.get_root_parse_node()
-	_analyzer = GDScriptASTAnalyzer.new(root)
 
 
 func test_addition_is_used_to_increase_level() -> String:

--- a/course/lesson-14-multiplying/increase_max_health/TestHealthIncreased.gd
+++ b/course/lesson-14-multiplying/increase_max_health/TestHealthIncreased.gd
@@ -2,25 +2,42 @@ extends PracticeTester
 
 var first_node: Node2D
 
+var _checker: GDScriptErrorChecker
+var _analyzer: GDScriptASTAnalyzer
+
+
 func _prepare():
 	first_node = _scene_root_viewport.get_child(0)
+	
+	_checker = GDScriptErrorChecker.new()
+	_checker.set_source(_slice.current_text)
+	var root := _checker.get_root_parse_node()
+	_analyzer = GDScriptASTAnalyzer.new(root)
 
 
 func test_addition_is_used_to_increase_level() -> String:
-	var regex = RegEx.new()
-	regex.compile("level\\s*\\+|\\+\\s*level")
-	var result = regex.search(_slice.current_text)
-	if not result:
+	var level_up_function := _analyzer.get_function_named("level_up")
+	
+	if (
+		# level += 1
+		not GDExpr.suite(GDExpr.assignment(GDExpr.identifier("level"), GDExpr.literal(1), GDAssignmentNode.Operation.OP_ADDITION)).matches(level_up_function) and
+		# level = level + 1
+		not GDExpr.suite(GDExpr.assignment(GDExpr.identifier("level"), GDExpr.bin_op(GDExpr.identifier("level"), GDExpr.literal(1), GDBinaryOpNode.OpType.OP_ADDITION, false))).matches(level_up_function)
+	):
 		return tr("It looks like level isn't increasing every level. Did you add 1 to it?")
 	return ""
 
 
 func test_multiplication_is_used_to_increase_max_health() -> String:
-	var regex = RegEx.new()
-	regex.compile("max_health\\s*\\*|\\*\\s*max_health")
-	var result = regex.search(_slice.current_text)
-	if not result:
-		return tr("It looks like max_health isn't increasing exponentially. Did you multiply it by a value greater than 1?")
+	var level_up_function := _analyzer.get_function_named("level_up")
+	
+	if (
+		# max_health *= 1.1
+		not GDExpr.suite(GDExpr.assignment(GDExpr.identifier("max_health"), GDExpr.literal(1.1), GDAssignmentNode.Operation.OP_MULTIPLICATION)).matches(level_up_function) and
+		# max_health = max_health * 1.1
+		not GDExpr.suite(GDExpr.assignment(GDExpr.identifier("max_health"), GDExpr.multiply(GDExpr.identifier("max_health"), GDExpr.literal(1.1)))).matches(level_up_function)
+	):
+		tr("It looks like max_health isn't increasing exponentially. Did you multiply it by a value greater than 1?")
 	return ""
 
 

--- a/course/lesson-14-multiplying/reducing_damage/TestReducingDamage.gd
+++ b/course/lesson-14-multiplying/reducing_damage/TestReducingDamage.gd
@@ -7,6 +7,9 @@ var first_node: Node2D
 var damage_taken_at_level_2 = -1
 var damage_taken_at_level_3 = -1
 
+var _checker: GDScriptErrorChecker
+var _analyzer: GDScriptASTAnalyzer
+
 func _prepare():
 	first_node = _scene_root_viewport.get_child(0)
 	
@@ -22,12 +25,50 @@ func _prepare():
 	var health_after_2 = first_node.health
 	damage_taken_at_level_3 = health_before_2 - health_after_2
 
+	_checker = GDScriptErrorChecker.new()
+	_checker.set_source(_slice.current_text)
+	var root := _checker.get_root_parse_node()
+	_analyzer = GDScriptASTAnalyzer.new(root)
+
 
 func test_multiplication_is_used_to_reduce_damage_amount() -> String:
-	var regex = RegEx.new()
-	regex.compile("amount\\s*\\*|\\*\\s*amount")
-	var result = regex.search(_slice.current_text)
-	if not result:
+	var take_damage_function := _analyzer.get_function_named("take_damage")
+	
+	if not take_damage_function:
+		return tr("It looks like the take_damage function is missing; did you remove it?")
+
+	var parameter_name := _analyzer.get_function_parameter_name(take_damage_function, 0)
+
+	if not GDExpr.suite(
+		GDExpr.if_block(
+			# condition: level > 2
+			GDExpr.bin_op(
+				GDExpr.identifier("level"),
+				GDExpr.literal(2),
+				GDBinaryOpNode.OpType.OP_COMP_GREATER
+			),
+			# truth block
+			GDExpr.suite(
+				# at least one of
+				GDExpr.any_of(
+					# amount *= 0.5
+					GDExpr.assignment(
+						GDExpr.identifier(parameter_name),
+						GDExpr.literal(0.5),
+						GDAssignmentNode.Operation.OP_MULTIPLICATION
+					),
+					# amount = amount * 0.5
+					GDExpr.assignment(
+						GDExpr.identifier(parameter_name),
+						GDExpr.multiply(
+							GDExpr.identifier(parameter_name),
+							GDExpr.literal(0.5)
+						)
+					)
+				)
+			)
+		)
+	).matches(take_damage_function):
 		return tr("It looks like amount isn't reduced by a percentage. Did you multiply it by a value less than 1?")
 	return ""
 

--- a/course/lesson-14-multiplying/reducing_damage/TestReducingDamage.gd
+++ b/course/lesson-14-multiplying/reducing_damage/TestReducingDamage.gd
@@ -7,8 +7,6 @@ var first_node: Node2D
 var damage_taken_at_level_2 = -1
 var damage_taken_at_level_3 = -1
 
-var _checker: GDScriptErrorChecker
-var _analyzer: GDScriptASTAnalyzer
 
 func _prepare():
 	first_node = _scene_root_viewport.get_child(0)
@@ -24,11 +22,6 @@ func _prepare():
 	first_node.take_damage(TEST_DAMAGE)
 	var health_after_2 = first_node.health
 	damage_taken_at_level_3 = health_before_2 - health_after_2
-
-	_checker = GDScriptErrorChecker.new()
-	_checker.set_source(_slice.current_text)
-	var root := _checker.get_root_parse_node()
-	_analyzer = GDScriptASTAnalyzer.new(root)
 
 
 func test_multiplication_is_used_to_reduce_damage_amount() -> String:

--- a/course/lesson-16-2d-vectors/increase_scale/TestScaleIncreased.gd
+++ b/course/lesson-16-2d-vectors/increase_scale/TestScaleIncreased.gd
@@ -1,17 +1,10 @@
 extends PracticeTester
 
 var first_node: Node2D
-var _checker: GDScriptErrorChecker
-var _analyzer: GDScriptASTAnalyzer
 
 
 func _prepare() -> void:
 	first_node = _scene_root_viewport.get_child(0)
-	
-	_checker = GDScriptErrorChecker.new()
-	_checker.set_source(_slice.current_text)
-	var root := _checker.get_root_parse_node()
-	_analyzer = GDScriptASTAnalyzer.new(root)
 
 
 func test_use_a_vector_to_increase_scale() -> String:

--- a/course/lesson-16-2d-vectors/increase_scale/TestScaleIncreased.gd
+++ b/course/lesson-16-2d-vectors/increase_scale/TestScaleIncreased.gd
@@ -1,18 +1,41 @@
 extends PracticeTester
 
 var first_node: Node2D
+var _checker: GDScriptErrorChecker
+var _analyzer: GDScriptASTAnalyzer
 
 
 func _prepare() -> void:
 	first_node = _scene_root_viewport.get_child(0)
+	
+	_checker = GDScriptErrorChecker.new()
+	_checker.set_source(_slice.current_text)
+	var root := _checker.get_root_parse_node()
+	_analyzer = GDScriptASTAnalyzer.new(root)
 
 
 func test_use_a_vector_to_increase_scale() -> String:
-	var regex = RegEx.new()
-	regex.compile("scale\\s*\\+.*Vector2|scale\\s*\\-.*Vector2|Vector2.*\\+.*scale")
-	var result = regex.search(_slice.current_text)
-	if not result:
+	var level_up_function := _analyzer.get_function_named("level_up")
+	
+	if not GDExpr.suite(
+		GDExpr.any_of(
+			GDExpr.assignment(
+				GDExpr.identifier("scale"),
+				GDExpr.literal(Vector2(0.2, 0.2), true),
+				GDAssignmentNode.OP_MULTIPLICATION
+			),
+			GDExpr.assignment(
+				GDExpr.identifier("scale"),
+				GDExpr.bin_op(
+					GDExpr.identifier("scale"),
+					GDExpr.literal(Vector2(0.2, 0.2), true),
+					GDBinaryOpNode.OP_MULTIPLICATION
+				)
+			)
+		)
+	).matches(level_up_function):
 		return tr("It looks like the scale isn't increasing by some vector. Did you add a vector to scale?")
+	
 	return ""
 
 

--- a/course/lesson-21-strings/string_array/TestsStringArray.gd
+++ b/course/lesson-21-strings/string_array/TestsStringArray.gd
@@ -2,17 +2,10 @@ extends PracticeTester
 
 var desired_combo = ["jab", "jab", "uppercut"]
 var robot: Node2D
-var _checker: GDScriptErrorChecker
-var _analyzer: GDScriptASTAnalyzer
 
 
 func _prepare() -> void:
 	robot = _scene_root_viewport.get_child(0)
-
-	_checker = GDScriptErrorChecker.new()
-	_checker.set_source(_slice.current_text)
-	var root := _checker.get_root_parse_node()
-	_analyzer = GDScriptASTAnalyzer.new(root)
 
 
 func test_use_for_loop() -> String:
@@ -74,13 +67,14 @@ func test_robot_combo_is_correct() -> String:
 
 	var run_function := _analyzer.get_function_named("run")
 	var combo_var := _analyzer.get_local_var_named(run_function, "combo")
-	var initializer := combo_var.get_initializer()
+	if combo_var:
+		var initializer := combo_var.get_initializer()
 
-	if GDExpr.array(
-		desired_combo.map(
-			func(animation_name: String) -> GDExpr: return GDExpr.literal(animation_name)
-		)
-	).matches(initializer):
-		return ""
+		if GDExpr.array(
+			desired_combo.map(
+				func(animation_name: String) -> GDExpr: return GDExpr.literal(animation_name)
+			)
+		).matches(initializer):
+			return ""
 	
 	return tr("The combo isn't correct. Did you use the right actions in the right order?")

--- a/course/lesson-21-strings/string_array/TestsStringArray.gd
+++ b/course/lesson-21-strings/string_array/TestsStringArray.gd
@@ -2,34 +2,68 @@ extends PracticeTester
 
 var desired_combo = ["jab", "jab", "uppercut"]
 var robot: Node2D
+var _checker: GDScriptErrorChecker
+var _analyzer: GDScriptASTAnalyzer
 
 
 func _prepare() -> void:
 	robot = _scene_root_viewport.get_child(0)
 
+	_checker = GDScriptErrorChecker.new()
+	_checker.set_source(_slice.current_text)
+	var root := _checker.get_root_parse_node()
+	_analyzer = GDScriptASTAnalyzer.new(root)
+
 
 func test_use_for_loop() -> String:
-	var regex = RegEx.new()
-	var variable_name = ""
-	regex.compile("for\\s+(\\w+)\\s+in")
-
-	var processed_code := _slice.preprocess_practice_code(_slice.current_text)
-
-	if not "for" in processed_code:
+	var run_function := _analyzer.get_function_named("run")
+	
+	if not run_function:
+		return tr("The run function is missing; did you remove it?")
+	
+	if not GDExpr.suite(GDExpr.for_loop(null, null, null)).matches(run_function):
 		return tr("Your code has no for loop. You need to use a for loop to complete this practice, even if there are other solutions!")
-
-	var result = regex.search(_slice.current_text)
-	if result:
-		variable_name = result.get_string(1)
-
-	if not "play_animation(" in processed_code:
+	
+	if not GDExpr.suite(
+		GDExpr.for_loop(
+			null,
+			null,
+			GDExpr.suite(
+				GDExpr.function_call("play_animation")
+			)
+		)
+	).matches(run_function):
 		return tr("Your code does not play any animations. Did you remember to call play_animation() in your for loop?")
-	if "play_animation(combo)" in processed_code:
+	
+	if GDExpr.suite(
+		GDExpr.for_loop(
+			null,
+			null,
+			GDExpr.suite(
+				GDExpr.function_call(
+					"play_animation",
+					GDExpr.identifier("combo")
+				)
+			)
+		)
+	).matches(run_function):
 		return tr("It seems you're passing the entire array of combos instead of a single animation name at a time.")
-	if not variable_name:
-		return tr("Your code has no iterator. You need to use a for loop with iterator to complete this practice, even if there are other solutions!")
-	if not "play_animation(" + variable_name + ")" in processed_code:
-		return tr("Your code does not use the iterator. Did you remember to call play_animation(%s) in your for loop?") % variable_name
+
+	var captures := {}
+	if not GDExpr.suite(
+		GDExpr.for_loop(
+			GDExpr.any_identifier().capture("animation_name", captures),
+			null,
+			GDExpr.suite(
+				GDExpr.function_call(
+					"play_animation",
+					GDExpr.captured_identifier("animation_name", captures)
+				)
+			)
+		)
+	).matches(run_function):
+		return tr("Your code does not use the iterator. Did you remember to call play_animation(%s) in your for loop?") % captures.animation_name
+	
 	return ""
 
 
@@ -38,18 +72,15 @@ func test_robot_combo_is_correct() -> String:
 	if robot_combo == desired_combo:
 		return ""
 
-	# Check if the student declared a local 'combo' variable and used it
-	# correctly in a for loop. Some students will shadow member variables with
-	# local ones so this still allows them to pass.
-	var processed_code := _slice.preprocess_practice_code(_slice.current_text)
-	if "varcombo" in processed_code or "combo=" in processed_code:
-		var regex = RegEx.new()
-		regex.compile("for(\\w+)incombo")
-		var result = regex.search(processed_code)
-		if result:
-			var iterator_name = result.get_string(1)
-			if ("play_animation(" + iterator_name + ")") in processed_code:
-				# Even with a local combo variable or if the student has the correct iterator, the combo must match desired_combo
-				if robot_combo == desired_combo:
-					return ""
+	var run_function := _analyzer.get_function_named("run")
+	var combo_var := _analyzer.get_local_var_named(run_function, "combo")
+	var initializer := combo_var.get_initializer()
+
+	if GDExpr.array(
+		desired_combo.map(
+			func(animation_name: String) -> GDExpr: return GDExpr.literal(animation_name)
+		)
+	).matches(initializer):
+		return ""
+	
 	return tr("The combo isn't correct. Did you use the right actions in the right order?")

--- a/course/lesson-25-creating-dictionaries/adding-items/TestAddingItems.gd
+++ b/course/lesson-25-creating-dictionaries/adding-items/TestAddingItems.gd
@@ -30,9 +30,48 @@ func test_add_item_function_works_as_intended():
 
 
 func test_add_item_function_uses_addition() -> String:
-	var regex = RegEx.new()
-	regex.compile("inventory.*\\+")
-	var result = regex.search(_slice.current_text)
-	if not result:
-		return tr("It doesn't look like you're adding amount to the value in the inventory dictionary.")
+	var add_item_function := _analyzer.get_function_named("add_item")
+	
+	var captures := {}
+	# func add_item(item_name, amount)
+	if not GDExpr.function(
+		&"add_item",
+		GDExpr.suite(
+			GDExpr.any_of(
+				# inventory[item_name] += amount
+				GDExpr.assignment(
+					GDExpr.subscript(
+						GDExpr.identifier("inventory"),
+						GDExpr.captured_identifier("item_name", captures)
+					),
+					GDExpr.captured_identifier("amount", captures),
+					GDAssignmentNode.OP_ADDITION
+				),
+				# inventory[item_name] = inventory[item_name] + amount
+				GDExpr.assignment(
+					GDExpr.subscript(
+						GDExpr.identifier("inventory"),
+						GDExpr.captured_identifier("item_name", captures)
+					),
+					GDExpr.bin_op(
+						GDExpr.subscript(
+							GDExpr.identifier("inventory"),
+							GDExpr.captured_identifier("item_name", captures),
+						),
+						GDExpr.captured_identifier("amount", captures),
+						GDBinaryOpNode.OP_ADDITION,
+						false,
+					),
+				)
+			)
+		),
+		GDExpr.parameter(
+			GDExpr.any_identifier().capture("item_name", captures)
+		),
+		GDExpr.parameter(
+			GDExpr.any_identifier().capture("amount", captures)
+		)
+	).matches(add_item_function):
+		return tr("It doesn't look like you're adding '%s' to the value in the inventory dictionary." % [captures.amount])
+	
 	return ""

--- a/course/lesson-26-looping-over-dictionaries/display-inventory/TestDisplayInventory.gd
+++ b/course/lesson-26-looping-over-dictionaries/display-inventory/TestDisplayInventory.gd
@@ -24,12 +24,14 @@ func test_all_items_are_displayed():
 
 
 func test_code_uses_a_for_loop():
-	var loops_over_inventory := false
-	for line in _slice.current_text.split("\n"):
-		if "for" in line and "inventory" in line:
-			loops_over_inventory = true
-			break
-
-	if not loops_over_inventory:
+	var run_function := _analyzer.get_function_named("run")
+	
+	if not GDExpr.suite(
+		GDExpr.for_loop(
+			GDExpr.any_identifier(),
+			GDExpr.identifier("inventory"),
+		)
+	).matches(run_function):
 		return tr("Your code has no for loop. You need to use a for loop to complete this practice, even if there are other solutions!")
+	
 	return ""

--- a/course/lesson-26-looping-over-dictionaries/place-units/TestPlaceUnits.gd
+++ b/course/lesson-26-looping-over-dictionaries/place-units/TestPlaceUnits.gd
@@ -23,12 +23,13 @@ func test_all_units_are_displayed():
 
 
 func test_code_uses_a_for_loop():
-	var loops_over_inventory := false
-	for line in _slice.current_text.split("\n"):
-		if "for" in line and "units" in line:
-			loops_over_inventory = true
-			break
-
-	if not loops_over_inventory:
+	var run_function := _analyzer.get_function_named("run")
+	
+	if not GDExpr.suite(
+		GDExpr.for_loop(
+			GDExpr.any_identifier(),
+			GDExpr.identifier("units")
+		)
+	).matches(run_function):
 		return tr("Your code has no for loop. You need to use a for loop to complete this practice, even if there are other solutions!")
 	return ""

--- a/course/lesson-9-adding-and-subtracting/taking-damage/TestDamagingRobot.gd
+++ b/course/lesson-9-adding-and-subtracting/taking-damage/TestDamagingRobot.gd
@@ -3,18 +3,10 @@ extends PracticeTester
 var first_node: Node2D
 var health := 0
 
-var _checker: GDScriptErrorChecker
-var _analyzer: GDScriptASTAnalyzer
-
 
 func _prepare() -> void:
 	first_node = _scene_root_viewport.get_child(0)
 	health = first_node.health
-
-	_checker = GDScriptErrorChecker.new()
-	_checker.set_source(_slice.current_text)
-	var root := _checker.get_root_parse_node()
-	_analyzer = GDScriptASTAnalyzer.new(root)
 
 
 func test_robot_takes_the_right_amount_of_damage() -> String:

--- a/course/lesson-9-adding-and-subtracting/taking-damage/TestDamagingRobot.gd
+++ b/course/lesson-9-adding-and-subtracting/taking-damage/TestDamagingRobot.gd
@@ -3,9 +3,19 @@ extends PracticeTester
 var first_node: Node2D
 var health := 0
 
-func _prepare():
+var _checker: GDScriptErrorChecker
+var _analyzer: GDScriptASTAnalyzer
+
+
+func _prepare() -> void:
 	first_node = _scene_root_viewport.get_child(0)
 	health = first_node.health
+
+	_checker = GDScriptErrorChecker.new()
+	_checker.set_source(_slice.current_text)
+	var root := _checker.get_root_parse_node()
+	_analyzer = GDScriptASTAnalyzer.new(root)
+
 
 func test_robot_takes_the_right_amount_of_damage() -> String:
 	if health > 100:
@@ -17,9 +27,30 @@ func test_robot_takes_the_right_amount_of_damage() -> String:
 	return ""
 
 func test_subtract_amount_from_health() -> String:
-	var regex = RegEx.new()
-	regex.compile("health\\s*-.*amount")
-	var result = regex.search(_slice.current_text)
-	if not result:
+	var take_damage_function := _analyzer.get_function_named("take_damage")
+	if not take_damage_function:
+		return tr("It looks like the take_damage function is missing; did you remove it?")
+	
+	var damage_parameter := _analyzer.get_function_parameter_name(take_damage_function, 0)
+	
+	if not GDExpr.suite(
+		GDExpr.any_of(
+			GDExpr.assignment(
+				GDExpr.identifier("health"),
+				GDExpr.identifier(damage_parameter),
+				GDAssignmentNode.Operation.OP_SUBTRACTION
+			),
+			GDExpr.assignment(
+				GDExpr.identifier("health"),
+				GDExpr.bin_op(
+					GDExpr.identifier("health"),
+					GDExpr.identifier(damage_parameter),
+					GDBinaryOpNode.OP_SUBTRACTION,
+					true
+				)
+			)
+		)
+	).matches(take_damage_function):
 		return tr("It doesn't look like you're subtracting amount from health.")
+	
 	return ""

--- a/script_checking/GDScriptASTAnalyzer.gd
+++ b/script_checking/GDScriptASTAnalyzer.gd
@@ -1,0 +1,154 @@
+class_name GDScriptASTAnalyzer
+extends GDScriptLocalAnalyzer
+
+
+var _student_class: GDClassNode
+
+
+func _init(student_class: GDClassNode) -> void:
+	_student_class = student_class
+
+
+func find_any_recursive_function() -> String:
+	var functions: Array[GDFunctionNode] = []
+	for member: GDMember in _student_class.get_members():
+		if member.get_type() != GDMember.FUNCTION:
+			continue
+		functions.push_back(member.get_as_function_node())
+	for function in functions:
+		var function_name := function.get_identifier().get_name()
+		var statements := function.get_body().get_statements()
+		for statement in statements:
+			if statement.get_type() == GDNode.CALL:
+				var call_node := statement as GDCallNode
+				if call_node.get_function_name() == function_name:
+					return function_name
+	return ""
+
+
+func has_infinite_while_loop() -> bool:
+	var functions: Array[GDFunctionNode] = []
+	for member: GDMember in _student_class.get_members():
+		if member.get_type() != GDMember.FUNCTION:
+			continue
+		functions.push_back(member.get_as_function_node())
+	for function in functions:
+		if _check_body_for_infinite_while(function.get_body()):
+			return true
+	return false
+
+
+func _check_body_for_infinite_while(suite: GDSuiteNode) -> bool:
+	var statements := suite.get_statements()
+	for statement in statements:
+		match statement.get_type():
+			GDNode.FOR:
+				var for_statement := statement as GDForNode
+				if _check_body_for_infinite_while(for_statement.get_loop()):
+					return true
+			GDNode.FUNCTION:
+				var function_statement := statement as GDFunctionNode
+				if _check_body_for_infinite_while(function_statement.get_body()):
+					return true
+			GDNode.IF:
+				var if_statement := statement as GDIfNode
+				var false_block := if_statement.get_false_block()
+				if (
+					_check_body_for_infinite_while(if_statement.get_true_block()) or
+					(false_block and _check_body_for_infinite_while(false_block))
+				):
+					return true
+			GDNode.MATCH:
+				var match_statement := statement as GDMatchNode
+				for branch in match_statement.get_branches():
+					if _check_body_for_infinite_while(branch.get_block()):
+						return true
+			GDNode.WHILE:
+				var while_statement := statement as GDWhileNode
+				if _is_while_loop_infinite(while_statement):
+					return true
+				if _check_body_for_infinite_while(while_statement.get_loop()):
+					return true
+			GDNode.LAMBDA:
+				var lambda_statement := statement as GDLambdaNode
+				if _check_body_for_infinite_while(lambda_statement.get_function().get_body()):
+					return true
+			GDNode.VARIABLE:
+				var variable_statement := statement as GDVariableNode
+				var initializer := variable_statement.get_initializer()
+				if initializer.get_type() == GDNode.LAMBDA:
+					var lambda_assignment := initializer as GDLambdaNode
+					if _check_body_for_infinite_while(lambda_assignment.get_function().get_body()):
+						return true
+	return false
+
+
+func _is_while_loop_infinite(loop: GDWhileNode) -> bool:
+	if _has_break_statement(loop.get_loop()):
+		return false
+	
+	var condition := loop.get_condition()
+	var literal_condition := condition as GDLiteralNode
+	# true, 1, -1.2
+	if literal_condition:
+		var value: Variant = literal_condition.get_reduced_value()
+		if (
+			(value is bool and value == true) or
+			(value is int and value != 0) or
+			(value is float and value != 0.0)
+		):
+			return true
+	
+	# 'not false', 'not 0', !false
+	var unary_condition := condition as GDUnaryOpNode
+	if unary_condition and unary_condition.get_operation() == GDUnaryOpNode.OP_LOGIC_NOT:
+		var operand := unary_condition.get_operand()
+		literal_condition = operand as GDLiteralNode
+		if literal_condition:
+			var value: Variant = literal_condition.get_reduced_value()
+			if (
+				(value is bool and value == false) or
+				(value is int and value == 0) or
+				(value is float and value == 0.0)
+			):
+				return true
+	
+	# math that amounts to non zero
+	var binary_op_condition := condition as GDBinaryOpNode
+	if binary_op_condition:
+		if binary_op_condition.get_left_operand() is GDLiteralNode and binary_op_condition.get_right_operand() is GDLiteralNode:
+			var value: Variant = binary_op_condition.get_reduced_value()
+			if (
+				(value is bool and value == true) or
+				(value is int and value != 0) or
+				(value is float and value != 0.0)
+			):
+				return true
+	
+	# TODO: ultimately we aren't catching function calls that will always return true
+	
+	return false
+
+
+func _has_break_statement(body: GDSuiteNode) -> bool:
+	for statement in body.get_statements():
+		match statement.get_type():
+			GDNode.BREAK:
+				return true
+			GDNode.IF:
+				var if_statement := statement as GDIfNode
+				if (
+					_has_break_statement(if_statement.get_true_block()) or
+					_has_break_statement(if_statement.get_false_block())
+				):
+					return true
+			GDNode.MATCH:
+				var match_statement := statement as GDMatchNode
+				for branch in match_statement.get_branches():
+					if _has_break_statement(branch.get_block()):
+						return true
+			# other suites include for/while loops (break will only break the nested loop)
+			# lambdas and variables with lambdas (break would be breaking a loop inside)
+			_:
+				pass
+	return false

--- a/script_checking/GDScriptASTAnalyzer.gd
+++ b/script_checking/GDScriptASTAnalyzer.gd
@@ -9,6 +9,61 @@ func _init(student_class: GDClassNode) -> void:
 	_student_class = student_class
 
 
+func get_function_named(name: StringName) -> GDFunctionNode:
+	if _student_class.has_function(name):
+		return _student_class.get_member(name).get_as_function_node()
+	return null
+
+
+func get_function_parameter_name(function: GDFunctionNode, index: int) -> StringName:
+	if index >= function.get_parameters().size():
+		return &""
+	return function.get_parameters()[index].get_identifier().name
+
+
+func get_statement_call_named(function_node: GDFunctionNode, name: StringName, starting_from_index := 0) -> GDCallNode:
+	var statements := function_node.get_body().get_statements()
+	for i: int in range(starting_from_index, statements.size()):
+		var call_statement: GDCallNode = statements[i] as GDCallNode
+		if call_statement and call_statement.get_function_name() == name:
+			return call_statement
+	return null
+
+
+func statement_is_call_named(statement: GDNode, name: StringName) -> bool:
+	return statement.get_type() == GDNode.CALL and (statement as GDCallNode).get_function_name() == name
+
+
+func call_has_argument_identifier(call_node: GDCallNode, parameter_index: int, name: StringName = &"") -> bool:
+	var arguments := call_node.get_arguments()
+	if parameter_index >= arguments.size():
+		return false
+	var argument := arguments[parameter_index] as GDIdentifierNode
+	if not argument:
+		return false
+	return argument.get_name() == name if name else true
+
+
+func call_has_argument_x_operated_by_identifier(call_node: GDCallNode, parameter_index: int, operator: GDBinaryOpNode.OpType, operand: StringName, value: Variant) -> bool:
+	var arguments := call_node.get_arguments()
+	if parameter_index >= arguments.size():
+		return false
+	var argument := arguments[parameter_index] as GDBinaryOpNode
+	if not argument or argument.get_operation() != operator:
+		return false
+	var left := argument.get_left_operand()
+	var right := argument.get_right_operand()
+	var ident: GDIdentifierNode
+	var lit: GDLiteralNode
+	if left.get_type() == GDNode.IDENTIFIER:
+		ident = left
+		lit = right
+	else:
+		ident = right
+		lit = left
+	return ident.get_name() == operand and lit.get_value() == value
+
+
 func find_any_recursive_function() -> String:
 	var functions: Array[GDFunctionNode] = []
 	for member: GDMember in _student_class.get_members():

--- a/script_checking/GDScriptASTAnalyzer.gd
+++ b/script_checking/GDScriptASTAnalyzer.gd
@@ -15,10 +15,29 @@ func get_function_named(name: StringName) -> GDFunctionNode:
 	return null
 
 
+func get_var_named(name: StringName) -> GDVariableNode:
+	if _student_class.has_member(name):
+		var member := _student_class.get_member(name)
+		if member.get_type() == GDNode.VARIABLE:
+			return member.get_as_signal_variable_node()
+	return null
+
+
 func get_function_parameter_name(function: GDFunctionNode, index: int) -> StringName:
 	if index >= function.get_parameters().size():
 		return &""
 	return function.get_parameters()[index].get_identifier().name
+
+
+func get_statement_assignment(function_node: GDFunctionNode, assignee: StringName, starting_from_index := 0) -> GDAssignmentNode:
+	var statements := function_node.get_body().get_statements()
+	for i: int in range(starting_from_index, statements.size()):
+		var assign_statement: GDAssignmentNode = statements[i] as GDAssignmentNode
+		if assign_statement:
+			var assignee_node := assign_statement.get_assignee() as GDIdentifierNode
+			if assignee_node and assignee_node.name == assignee:
+				return assign_statement
+	return null
 
 
 func get_statement_call_named(function_node: GDFunctionNode, name: StringName, starting_from_index := 0) -> GDCallNode:
@@ -30,38 +49,13 @@ func get_statement_call_named(function_node: GDFunctionNode, name: StringName, s
 	return null
 
 
-func statement_is_call_named(statement: GDNode, name: StringName) -> bool:
-	return statement.get_type() == GDNode.CALL and (statement as GDCallNode).get_function_name() == name
-
-
-func call_has_argument_identifier(call_node: GDCallNode, parameter_index: int, name: StringName = &"") -> bool:
-	var arguments := call_node.get_arguments()
-	if parameter_index >= arguments.size():
-		return false
-	var argument := arguments[parameter_index] as GDIdentifierNode
-	if not argument:
-		return false
-	return argument.get_name() == name if name else true
-
-
-func call_has_argument_x_operated_by_identifier(call_node: GDCallNode, parameter_index: int, operator: GDBinaryOpNode.OpType, operand: StringName, value: Variant) -> bool:
-	var arguments := call_node.get_arguments()
-	if parameter_index >= arguments.size():
-		return false
-	var argument := arguments[parameter_index] as GDBinaryOpNode
-	if not argument or argument.get_operation() != operator:
-		return false
-	var left := argument.get_left_operand()
-	var right := argument.get_right_operand()
-	var ident: GDIdentifierNode
-	var lit: GDLiteralNode
-	if left.get_type() == GDNode.IDENTIFIER:
-		ident = left
-		lit = right
-	else:
-		ident = right
-		lit = left
-	return ident.get_name() == operand and lit.get_value() == value
+func get_local_var_named(function_node: GDFunctionNode, name: StringName, starting_from_index := 0) -> GDVariableNode:
+	var statements := function_node.get_body().get_statements()
+	for i: int in range(starting_from_index, statements.size()):
+		var var_statement := statements[i] as GDVariableNode
+		if var_statement and var_statement.get_identifier().name == name:
+			return var_statement
+	return null
 
 
 func find_any_recursive_function() -> String:

--- a/script_checking/GDScriptASTAnalyzer.gd
+++ b/script_checking/GDScriptASTAnalyzer.gd
@@ -2,22 +2,22 @@ class_name GDScriptASTAnalyzer
 extends GDScriptLocalAnalyzer
 
 
-var _student_class: GDClassNode
+var root: GDClassNode
 
 
 func _init(student_class: GDClassNode) -> void:
-	_student_class = student_class
+	root = student_class
 
 
 func get_function_named(name: StringName) -> GDFunctionNode:
-	if _student_class.has_function(name):
-		return _student_class.get_member(name).get_as_function_node()
+	if root.has_function(name):
+		return root.get_member(name).get_as_function_node()
 	return null
 
 
 func get_var_named(name: StringName) -> GDVariableNode:
-	if _student_class.has_member(name):
-		var member := _student_class.get_member(name)
+	if root.has_member(name):
+		var member := root.get_member(name)
 		if member.get_type() == GDNode.VARIABLE:
 			return member.get_as_signal_variable_node()
 	return null
@@ -60,7 +60,7 @@ func get_local_var_named(function_node: GDFunctionNode, name: StringName, starti
 
 func find_any_recursive_function() -> String:
 	var functions: Array[GDFunctionNode] = []
-	for member: GDMember in _student_class.get_members():
+	for member: GDMember in root.get_members():
 		if member.get_type() != GDMember.FUNCTION:
 			continue
 		functions.push_back(member.get_as_function_node())
@@ -77,7 +77,7 @@ func find_any_recursive_function() -> String:
 
 func has_infinite_while_loop() -> bool:
 	var functions: Array[GDFunctionNode] = []
-	for member: GDMember in _student_class.get_members():
+	for member: GDMember in root.get_members():
 		if member.get_type() != GDMember.FUNCTION:
 			continue
 		functions.push_back(member.get_as_function_node())

--- a/script_checking/GDScriptASTAnalyzer.gd.uid
+++ b/script_checking/GDScriptASTAnalyzer.gd.uid
@@ -1,0 +1,1 @@
+uid://ck26pck4n6xbq

--- a/script_checking/GDScriptLocalAnalyzer.gd
+++ b/script_checking/GDScriptLocalAnalyzer.gd
@@ -1,0 +1,9 @@
+@abstract
+class_name GDScriptLocalAnalyzer
+extends RefCounted
+
+
+@abstract
+func find_any_recursive_function() -> String
+@abstract
+func has_infinite_while_loop() -> bool

--- a/script_checking/GDScriptLocalAnalyzer.gd.uid
+++ b/script_checking/GDScriptLocalAnalyzer.gd.uid
@@ -1,0 +1,1 @@
+uid://b1ct36cqf0nrr

--- a/script_checking/MiniGDScriptTokenizer.gd
+++ b/script_checking/MiniGDScriptTokenizer.gd
@@ -17,6 +17,7 @@
 # `_current_scope`, which makes it so every subsequent line gets appended to its
 # body
 class_name MiniGDScriptTokenizer
+extends GDScriptLocalAnalyzer
 
 const TOKEN_FUNC_DECLARATION := "function_declaration"
 const TOKEN_FUNC_CALL := "function_call"

--- a/script_checking/OfflineScriptVerifier.gd
+++ b/script_checking/OfflineScriptVerifier.gd
@@ -15,6 +15,7 @@ const PARSE_WRAPPER_CLASS := "GDScriptErrorChecker"
 
 # Array[ScriptError]
 var errors := []
+var _wrap_instance: RefCounted
 
 
 func _init(new_script_text: String) -> void:
@@ -23,25 +24,23 @@ func _init(new_script_text: String) -> void:
 
 
 func test() -> void:
-	if ClassDB.class_exists(PARSE_WRAPPER_CLASS):
-		var wrap_instance: RefCounted = ClassDB.instantiate(PARSE_WRAPPER_CLASS)
+	_update_instance_if_missing()
+	if _wrap_instance:
 		@warning_ignore("unsafe_method_access")
-		wrap_instance.set_source(_new_script_text)
-		@warning_ignore("unsafe_method_access")
-		if wrap_instance.has_errors():
+		if _wrap_instance.has_errors():
 			errors = []
 			var lines := _new_script_text.split("\n")
 			@warning_ignore("unsafe_method_access")
-			for i: int in wrap_instance.get_error_count():
+			for i: int in _wrap_instance.get_error_count():
 				@warning_ignore("unsafe_method_access")
-				var error_line: int = wrap_instance.get_error_line(i)
+				var error_line: int = _wrap_instance.get_error_line(i)
 				@warning_ignore("unsafe_method_access")
 				error_line = clampi(error_line - 1, 0, lines.size()-1)
 				var line_text := lines[error_line]
 				@warning_ignore("unsafe_method_access")
 				var error_data := make_error_from_data(
 					1,
-					wrap_instance.get_error(i) as String,
+					_wrap_instance.get_error(i) as String,
 					"gdscript",
 					-1,
 					error_line,
@@ -56,6 +55,21 @@ func test() -> void:
 		var error := make_error_no_parser_wrapper_class()
 		errors = [error]
 		return
+
+
+func _update_instance_if_missing() -> void:
+	if _wrap_instance == null and ClassDB.class_exists(PARSE_WRAPPER_CLASS):
+		_wrap_instance = ClassDB.instantiate(PARSE_WRAPPER_CLASS)
+		@warning_ignore("unsafe_method_access")
+		_wrap_instance.set_source(_new_script_text)
+
+
+func get_class_ast() -> RefCounted:
+	_update_instance_if_missing()
+	if _wrap_instance:
+		@warning_ignore("unsafe_method_access")
+		return _wrap_instance.get_root_parse_node()
+	return null
 
 
 static func make_error_no_parser_wrapper_class() -> ScriptError:

--- a/script_checking/PracticeTester.gd
+++ b/script_checking/PracticeTester.gd
@@ -18,6 +18,8 @@ var _scene_root_viewport: Node
 var _slice: ScriptSlice
 var _test_methods := _find_test_method_names()
 var _code_lines := []
+var _checker: GDScriptErrorChecker
+var _analyzer: GDScriptASTAnalyzer
 
 
 # We're not using _init() because it doesn't work unless you define it and call the parent's constructor in child classes. It would add boilerplate to every PracticeTester script.
@@ -30,10 +32,18 @@ func get_test_names() -> Array:
 	return _test_methods.values()
 
 
+func _update_analyzer() -> void:
+	_checker = GDScriptErrorChecker.new()
+	_checker.set_source(_slice.current_text)
+	var root := _checker.get_root_parse_node()
+	_analyzer = GDScriptASTAnalyzer.new(root)
+
+
 func run_tests() -> TestResult:
 	var result := TestResult.new()
 
 	_code_lines.clear()
+	_update_analyzer()
 	_prepare()
 
 	for method: StringName in _test_methods:

--- a/script_checking/ast_analyzer/GDAnyExpr.gd
+++ b/script_checking/ast_analyzer/GDAnyExpr.gd
@@ -1,0 +1,6 @@
+class_name GDAnyExpr
+extends GDExpr
+
+
+func matches(_node: GDNode) -> bool:
+	return true

--- a/script_checking/ast_analyzer/GDAnyExpr.gd.uid
+++ b/script_checking/ast_analyzer/GDAnyExpr.gd.uid
@@ -1,0 +1,1 @@
+uid://boxuyh46cu0so

--- a/script_checking/ast_analyzer/GDAnyOfExpr.gd
+++ b/script_checking/ast_analyzer/GDAnyOfExpr.gd
@@ -1,0 +1,14 @@
+class_name GDAnyOfExpr
+extends GDExpr
+
+
+var _expressions: Array[GDExpr] = []
+
+func _init(expressions: Array) -> void:
+	for expression in expressions:
+		assert(expression is GDExpr, "Can only accept GDExpr types")
+		_expressions.push_back(expression)
+
+
+func matches(node: GDNode) -> bool:
+	return _expressions.any(func(expression: GDExpr) -> bool: return expression.matches(node))

--- a/script_checking/ast_analyzer/GDAnyOfExpr.gd.uid
+++ b/script_checking/ast_analyzer/GDAnyOfExpr.gd.uid
@@ -1,0 +1,1 @@
+uid://dlxsougiycp04

--- a/script_checking/ast_analyzer/GDArrayExpr.gd
+++ b/script_checking/ast_analyzer/GDArrayExpr.gd
@@ -1,0 +1,22 @@
+class_name GDArrayExpr
+extends GDExpr
+
+
+var _elements: Array[GDExpr]
+
+
+func _init(elements: Array[GDExpr]) -> void:
+	_elements = elements
+
+
+func matches(node: GDNode) -> bool:
+	if node.get_type() != GDNode.ARRAY:
+		return false
+	var array_node := node as GDArrayNode
+	var elements := array_node.get_elements()
+	if elements.size() < _elements.size():
+		return false
+	for i in _elements.size():
+		if not _elements[i].matches(elements[i]):
+			return false
+	return true

--- a/script_checking/ast_analyzer/GDArrayExpr.gd.uid
+++ b/script_checking/ast_analyzer/GDArrayExpr.gd.uid
@@ -1,0 +1,1 @@
+uid://cr8tsbcbqm2t

--- a/script_checking/ast_analyzer/GDAssignExpr.gd
+++ b/script_checking/ast_analyzer/GDAssignExpr.gd
@@ -1,0 +1,19 @@
+class_name GDAssignExpr
+extends GDExpr
+
+
+var _assignee: GDExpr
+var _operation: GDAssignmentNode.Operation
+var _assignment_expr: GDExpr
+
+func _init(assignee: GDExpr, assignment_expr: GDExpr, operation: GDAssignmentNode.Operation) -> void:
+	_assignee = assignee
+	_assignment_expr = assignment_expr
+	_operation = operation
+
+
+func matches(node: GDNode) -> bool:
+	if node.get_type() != GDNode.ASSIGNMENT:
+		return false
+	var assignment_node := node as GDAssignmentNode
+	return assignment_node.get_operation() == _operation and _assignee.matches(assignment_node.get_assignee()) and _assignment_expr.matches(assignment_node.get_assigned_value())

--- a/script_checking/ast_analyzer/GDAssignExpr.gd.uid
+++ b/script_checking/ast_analyzer/GDAssignExpr.gd.uid
@@ -1,0 +1,1 @@
+uid://dnaj2pw0s7bs2

--- a/script_checking/ast_analyzer/GDBinaryOpExpr.gd
+++ b/script_checking/ast_analyzer/GDBinaryOpExpr.gd
@@ -1,0 +1,24 @@
+class_name GDBinaryOpExpr
+extends GDExpr
+
+
+var _operands: Array[GDExpr] = []
+var _strict_order := false
+var _type: GDBinaryOpNode.OpType
+
+func _init(operand_a: GDExpr, operand_b: GDExpr, type: GDBinaryOpNode.OpType, strict_order: bool) -> void:
+	_operands = [operand_a, operand_b]
+	_strict_order = strict_order
+	_type = type
+
+
+func matches(node: GDNode) -> bool:
+	if node.get_type() != GDNode.BINARY_OPERATOR:
+		return false
+	var binary_op := node as GDBinaryOpNode
+	if binary_op.operation != _type:
+		return false
+	var does_match := _operands[0].matches(binary_op.left) and _operands[1].matches(binary_op.right)
+	if not does_match and not _strict_order:
+		does_match = _operands[1].matches(binary_op.left) and _operands[0].matches(binary_op.right)
+	return does_match

--- a/script_checking/ast_analyzer/GDBinaryOpExpr.gd.uid
+++ b/script_checking/ast_analyzer/GDBinaryOpExpr.gd.uid
@@ -1,0 +1,1 @@
+uid://ckd5kxeme8ssk

--- a/script_checking/ast_analyzer/GDCallExpr.gd
+++ b/script_checking/ast_analyzer/GDCallExpr.gd
@@ -1,0 +1,28 @@
+class_name GDCallExpr
+extends GDExpr
+
+
+var _name: StringName
+var _arguments: Array[GDExpr]
+
+func _init(name: StringName, arguments: Array[GDExpr]) -> void:
+	_name = name
+	_arguments = arguments
+
+
+func matches(node: GDNode) -> bool:
+	if node.get_type() != GDNode.CALL:
+		return false
+	var call_node := node as GDCallNode
+	if call_node.get_function_name() != _name:
+		return false
+	var call_arguments := call_node.get_arguments()
+	if call_arguments.size() < _arguments.size():
+		return false
+	for i in _arguments.size():
+		var argument: GDExpr = _arguments[i]
+		if argument == null:
+			continue
+		if not argument.matches(call_arguments[i]):
+			return false
+	return call_node.get_function_name() == _name

--- a/script_checking/ast_analyzer/GDCallExpr.gd.uid
+++ b/script_checking/ast_analyzer/GDCallExpr.gd.uid
@@ -1,0 +1,1 @@
+uid://bx5o3baoyih06

--- a/script_checking/ast_analyzer/GDCaptureExpr.gd
+++ b/script_checking/ast_analyzer/GDCaptureExpr.gd
@@ -1,0 +1,14 @@
+class_name GDCaptureExpr
+extends GDIdentifierExpr
+
+
+func _init(name: StringName, captures: Dictionary) -> void:
+	_name = name
+	_captures = captures
+
+
+func matches(node: GDNode) -> bool:
+	if node.get_type() != GDNode.IDENTIFIER:
+		return false
+	var ident_node := node as GDIdentifierNode
+	return ident_node.name == _captures[_name]

--- a/script_checking/ast_analyzer/GDCaptureExpr.gd.uid
+++ b/script_checking/ast_analyzer/GDCaptureExpr.gd.uid
@@ -1,0 +1,1 @@
+uid://b1kdklnmwm70y

--- a/script_checking/ast_analyzer/GDExpr.gd
+++ b/script_checking/ast_analyzer/GDExpr.gd
@@ -1,0 +1,287 @@
+## Expressions that are used to match against the parser's nodes
+## e.g.
+## [code]
+## if not GDExpr.function_call("rotate",
+##			GDExpr.multiply(GDExpr.literal(2.0), GDExpr.identifier(process_delta_name))
+##	).matches(rotate_call):
+##		print("Does not match 'rotate(2 * delta)'")
+## [/code]
+@abstract
+class_name GDExpr
+extends RefCounted
+
+
+## Will return true if the expression and any sub-expression it depends match against a node and its children
+@abstract
+func matches(node: GDNode) -> bool
+
+
+## Creates an expression that will match a GDNode to a binary op node that uses OP_MULITPLICATION between
+## its two operands. If strict is true, the order matters as left, right, otherwise either will do
+static func multiply(operand_a: GDExpr, operand_b: GDExpr, strict: bool = false) -> GDBinaryOpExpr:
+	return bin_op(operand_a, operand_b, GDBinaryOpNode.OP_MULTIPLICATION, strict)
+
+
+## Creates an expression that will match a GDNode to a binary op node of operation type between
+## its two operands. If strict is true, the order matters as left, right, otherwise either will do.
+static func bin_op(operand_a: GDExpr, operand_b: GDExpr, operation: GDBinaryOpNode.OpType, strict: bool = true) -> GDBinaryOpExpr:
+	var new_expr := GDBinaryOpExpr.new(operand_a, operand_b, operation, strict)
+	return new_expr
+
+
+## Creates an expression that will match a GDNode to an identifier by name
+## Make regex true to match using a regex string
+static func identifier(name: String, as_regex := false) -> GDIdentifierExpr:
+	var new_expr := GDIdentifierExpr.new(name, as_regex)
+	return new_expr
+
+
+## Creates an expression that will match a GDNode to a literal.
+## If approx_equal is true, will use is_equal_approx, otherwise ==
+## If ignore_value is true, will match with any literal node
+static func literal(value: Variant, approx_equal: bool = false, ignore_value: bool = false) -> GDLiteralExpr:
+	var new_expr := GDLiteralExpr.new(value, approx_equal, ignore_value)
+	return new_expr
+
+
+## Creates an expression that will match a GDNode to an assignment
+static func assignment(assignee: GDExpr, assignment_expr: GDExpr, operation: GDAssignmentNode.Operation = GDAssignmentNode.Operation.OP_NONE) -> GDAssignExpr:
+	var new_expr := GDAssignExpr.new(assignee, assignment_expr, operation)
+	return new_expr
+
+
+static func if_block(condition: GDExpr, truth_block: GDExpr = null, false_block: GDExpr = null) -> GDIfExpr:
+	var new_expr := GDIfExpr.new(condition, truth_block, false_block)
+	return new_expr
+
+
+static func suite(...statements) -> GDSuiteExpr:
+	var new_expr := GDSuiteExpr.new(statements as Array)
+	return new_expr
+
+
+## Creates an expression that will always match to any node
+static func any() -> GDAnyExpr:
+	return GDAnyExpr.new()
+
+
+static func any_of(...expressions) -> GDAnyOfExpr:
+	return GDAnyOfExpr.new(expressions as Array)
+
+
+## Creates an expression that will match a function by its name and arguments
+## Any arguments that you do not want to match should be null
+static func function_call(name: StringName, ...arguments) -> GDCallExpr:
+	var typed_arguments: Array[GDExpr] = []
+	for argument in arguments:
+		typed_arguments.push_back(argument)
+	var new_expr := GDCallExpr.new(name, typed_arguments)
+	return new_expr
+
+
+class GDAnyOfExpr extends GDExpr:
+	var _expressions: Array[GDExpr] = []
+	
+	func _init(expressions: Array) -> void:
+		for expression in expressions:
+			assert(expression is GDExpr, "Can only accept GDExpr types")
+			_expressions.push_back(expression)
+	
+	
+	func matches(node: GDNode) -> bool:
+		return _expressions.any(func(expression: GDExpr) -> bool: return expression.matches(node))
+
+
+class GDSuiteExpr extends GDExpr:
+	var _statements: Array[GDExpr] = []
+	
+	func _init(statements: Array) -> void:
+		for statement: GDExpr in statements:
+			assert(statement, "Can only accept GDExpr arguments")
+			_statements.push_back(statement)
+	
+
+	func matches(node: GDNode) -> bool:
+		var suite_node: GDSuiteNode = null
+		if node.get_type() == GDNode.FUNCTION:
+			suite_node = (node as GDFunctionNode).get_body()
+		elif node.get_type() == GDNode.SUITE:
+			suite_node = node as GDSuiteNode
+		else:
+			return false
+		
+		var suite_statements := suite_node.get_statements()
+		
+		for statement_expression: GDExpr in _statements:
+			var found_match := false
+			for suite_statement: GDNode in suite_statements:
+				if statement_expression.matches(suite_statement):
+					found_match = true
+					break
+			if not found_match:
+				return false
+		return true
+
+
+class GDIfExpr extends GDExpr:
+	var _condition: GDExpr
+	var _truth_block: GDExpr
+	var _false_block: GDExpr
+	
+	func _init(condition: GDExpr, truth_block: GDExpr = null, false_block: GDExpr = null) -> void:
+		_condition = condition
+		_truth_block = truth_block
+		_false_block = false_block
+	
+	
+	func matches(node: GDNode) -> bool:
+		if node.get_type() != GDNode.IF:
+			return false
+		var if_node := node as GDIfNode
+		
+		return (
+			_condition.matches(if_node.get_condition()) and
+			(not _truth_block or _truth_block.matches(if_node.get_true_block())) and
+			(not _false_block or _false_block.matches(if_node.get_false_block()))
+		)
+
+
+class GDAssignExpr extends GDExpr:
+	var _assignee: GDExpr
+	var _operation: GDAssignmentNode.Operation
+	var _assignment_expr: GDExpr
+	
+	func _init(assignee: GDExpr, assignment_expr: GDExpr, operation: GDAssignmentNode.Operation) -> void:
+		_assignee = assignee
+		_assignment_expr = assignment_expr
+		_operation = operation
+
+
+	func matches(node: GDNode) -> bool:
+		if node.get_type() != GDNode.ASSIGNMENT:
+			return false
+		var assignment_node := node as GDAssignmentNode
+		return assignment_node.get_operation() == _operation and _assignee.matches(assignment_node.get_assignee()) and _assignment_expr.matches(assignment_node.get_assigned_value())
+
+
+
+class GDAnyExpr extends GDExpr:
+	func matches(_node: GDNode) -> bool:
+		return true
+
+
+class GDCallExpr extends GDExpr:
+	var _name: StringName
+	var _arguments: Array[GDExpr]
+	
+	func _init(name: StringName, arguments: Array[GDExpr]) -> void:
+		_name = name
+		_arguments = arguments
+
+
+	func matches(node: GDNode) -> bool:
+		if node.get_type() != GDNode.CALL:
+			return false
+		var call_node := node as GDCallNode
+		if call_node.get_function_name() != _name:
+			return false
+		var call_arguments := call_node.get_arguments()
+		if call_arguments.size() < _arguments.size():
+			return false
+		for i in _arguments.size():
+			var argument: GDExpr = _arguments[i]
+			if argument == null:
+				continue
+			if not argument.matches(call_arguments[i]):
+				return false
+		return call_node.get_function_name() == _name
+
+
+class GDLiteralExpr extends GDExpr:
+	var _value: Variant
+	var _any_value := false
+	var _approx := false
+
+
+	func _init(value: Variant, approx: bool, any_value: bool) -> void:
+		_value = value
+		_any_value = any_value
+		_approx = approx
+
+
+	func matches(node: GDNode) -> bool:
+		if node.get_type() != GDNode.LITERAL:
+			return false
+		if _any_value:
+			return true
+		var lit_node := node as GDLiteralNode
+		if _approx:
+			if _value is float and lit_node.get_value() is float:
+				return is_equal_approx(lit_node.value as float, _value as float)
+			elif _value is AABB and lit_node.get_value() is AABB:
+				return (_value as AABB).is_equal_approx(lit_node.get_value() as AABB)
+			elif _value is Basis and lit_node.get_value() is Basis:
+				return (_value as Basis).is_equal_approx(lit_node.get_value() as Basis)
+			elif _value is Color and lit_node.get_value() is Color:
+				return (_value as Color).is_equal_approx(lit_node.get_value() as Color)
+			elif _value is Plane and lit_node.get_value() is Plane:
+				return (_value as Plane).is_equal_approx(lit_node.get_value() as Plane)
+			elif _value is Quaternion and lit_node.get_value() is Quaternion:
+				return (_value as Quaternion).is_equal_approx(lit_node.get_value() as Quaternion)
+			elif _value is Rect2 and lit_node.get_value() is Rect2:
+				return (_value as Rect2).is_equal_approx(lit_node.get_value() as Rect2)
+			elif _value is Transform2D and lit_node.get_value() is Transform2D:
+				return (_value as Transform2D).is_equal_approx(lit_node.get_value() as Transform2D)
+			elif _value is Transform3D and lit_node.get_value() is Transform3D:
+				return (_value as Transform3D).is_equal_approx(lit_node.get_value() as Transform3D)
+			elif _value is Vector2 and lit_node.get_value() is Vector2:
+				return (_value as Vector2).is_equal_approx(lit_node.get_value() as Vector2)
+			elif _value is Vector3 and lit_node.get_value() is Vector3:
+				return (_value as Vector3).is_equal_approx(lit_node.get_value() as Vector3)
+			elif _value is Vector4 and lit_node.get_value() is Vector4:
+				return (_value as Vector4).is_equal_approx(lit_node.get_value() as Vector4)
+		return lit_node.value == _value
+
+
+class GDIdentifierExpr extends GDExpr:
+	var _name: String
+	var _regex: RegEx = null
+	
+	func _init(name: String, use_regex: bool) -> void:
+		_name = name
+		if use_regex:
+			_regex = RegEx.create_from_string(name)
+
+
+	func matches(node: GDNode) -> bool:
+		if node.get_type() != GDNode.IDENTIFIER:
+			return false
+		
+		var ident_node := node as GDIdentifierNode
+		if _regex:
+			return _regex.search(ident_node.name) != null
+		else:
+			return ident_node.name == _name
+
+
+class GDBinaryOpExpr extends GDExpr:
+	var _operands: Array[GDExpr] = []
+	var _strict_order := false
+	var _type: GDBinaryOpNode.OpType
+	
+	func _init(operand_a: GDExpr, operand_b: GDExpr, type: GDBinaryOpNode.OpType, strict_order: bool) -> void:
+		_operands = [operand_a, operand_b]
+		_strict_order = strict_order
+		_type = type
+
+
+	func matches(node: GDNode) -> bool:
+		if node.get_type() != GDNode.BINARY_OPERATOR:
+			return false
+		var binary_op := node as GDBinaryOpNode
+		if binary_op.operation != _type:
+			return false
+		var does_match := _operands[0].matches(binary_op.left) and _operands[1].matches(binary_op.right)
+		if not does_match and not _strict_order:
+			does_match = _operands[1].matches(binary_op.left) and _operands[0].matches(binary_op.right)
+		return does_match

--- a/script_checking/ast_analyzer/GDExpr.gd
+++ b/script_checking/ast_analyzer/GDExpr.gd
@@ -95,6 +95,80 @@ static func function_call(name: StringName, ...arguments) -> GDCallExpr:
 	return new_expr
 
 
+static func for_loop(loop_variable: GDIdentifierExpr = null, list: GDExpr = null, body: GDSuiteExpr = null) -> GDForExpr:
+	return GDForExpr.new(loop_variable, list, body)
+
+
+static func captured_identifier(name: StringName, captures: Dictionary) -> GDCaptureExpr:
+	return GDCaptureExpr.new(name, captures)
+
+
+static func array(elements: Array) -> GDArrayExpr:
+	var new_elements: Array[GDExpr] = []
+	for element in elements:
+		assert(element is GDExpr, "Can only accept GDExpr elements")
+		new_elements.push_back(element)
+	return GDArrayExpr.new(new_elements)
+
+
+class GDArrayExpr extends GDExpr:
+	var _elements: Array[GDExpr]
+	
+	
+	func _init(elements: Array[GDExpr]) -> void:
+		_elements = elements
+	
+
+	func matches(node: GDNode) -> bool:
+		if node.get_type() != GDNode.ARRAY:
+			return false
+		var array_node := node as GDArrayNode
+		var elements := array_node.get_elements()
+		if elements.size() < _elements.size():
+			return false
+		for i in _elements.size():
+			if not _elements[i].matches(elements[i]):
+				return false
+		return true
+
+
+class GDCaptureExpr extends GDIdentifierExpr:
+	func _init(name: StringName, captures: Dictionary) -> void:
+		_name = name
+		_captures = captures
+	
+	
+	func matches(node: GDNode) -> bool:
+		if node.get_type() != GDNode.IDENTIFIER:
+			return false
+		var ident_node := node as GDIdentifierNode
+		return ident_node.name == _captures[_name]
+
+
+class GDForExpr extends GDExpr:
+	var _loop_variable: GDExpr
+	var _body: GDExpr
+	var _list: GDExpr
+	
+	func _init(loop_variable: GDIdentifierExpr = null, list: GDExpr = null, body: GDSuiteExpr = null) -> void:
+		_loop_variable = loop_variable
+		_body = body
+		_list = list
+	
+	
+	func matches(node: GDNode) -> bool:
+		if node.get_type() != GDNode.FOR:
+			return false
+		var for_node := node as GDForNode
+		if (
+			(_loop_variable and not _loop_variable.matches(for_node.get_variable())) or
+			(_list and not _list.matches(for_node.get_list())) or
+			(_body and not _body.matches(for_node.get_loop()))
+		):
+			return false
+		return true
+
+
 class GDAnyOfExpr extends GDExpr:
 	var _expressions: Array[GDExpr] = []
 	
@@ -256,13 +330,17 @@ class GDLiteralExpr extends GDExpr:
 				return (_value as Vector3).is_equal_approx(lit_node.get_value() as Vector3)
 			elif _value is Vector4 and lit_node.get_value() is Vector4:
 				return (_value as Vector4).is_equal_approx(lit_node.get_value() as Vector4)
-		return lit_node.value == _value
+		var value: Variant = lit_node.value
+		return value == _value
 
 
 class GDIdentifierExpr extends GDExpr:
 	var _name: String
 	var _regex: RegEx = null
-	
+	var _do_capture := false
+	var _capture_name: StringName
+	var _captures: Dictionary
+
 	func _init(name: String, use_regex: bool) -> void:
 		_name = name
 		if use_regex:
@@ -274,10 +352,22 @@ class GDIdentifierExpr extends GDExpr:
 			return false
 		
 		var ident_node := node as GDIdentifierNode
+		var does_match := false
 		if _regex:
-			return _regex.search(ident_node.name) != null
+			does_match = _regex.search(ident_node.name) != null
 		else:
-			return ident_node.name == _name
+			does_match = ident_node.name == _name
+		if _do_capture:
+			_captures[_capture_name] = ident_node.name
+		return does_match
+
+
+	func capture(name: StringName, captures: Dictionary) -> GDIdentifierExpr:
+		_capture_name = name
+		_captures = captures
+		_captures[_capture_name] = &""
+		_do_capture = true
+		return self
 
 
 class GDBinaryOpExpr extends GDExpr:

--- a/script_checking/ast_analyzer/GDExpr.gd
+++ b/script_checking/ast_analyzer/GDExpr.gd
@@ -1,17 +1,24 @@
 ## Expressions that are used to match against the parser's nodes
 ## e.g.
-## [code]
-## if not GDExpr.function_call("rotate",
-##			GDExpr.multiply(GDExpr.literal(2.0), GDExpr.identifier(process_delta_name))
-##	).matches(rotate_call):
-##		print("Does not match 'rotate(2 * delta)'")
-## [/code]
+## [codeblock]
+## var process := _analyzer.get_function_named("_process")
+## if not GDExpr.suite(
+## 		GDExpr.function_call(
+## 			"rotate",
+## 			GDExpr.multiply(
+## 				GDExpr.literal(2.0),
+## 				GDExpr.identifier(process_delta_name)
+## 			)
+## 		)
+## 	).matches(process):
+## 		return tr("The rotation speed is not right. The robot should rotate 2 radians per second. Make sure the call looks like this: rotate(2 * delta).")
+## [/codeblock]
 @abstract
 class_name GDExpr
 extends RefCounted
 
 
-## Will return true if the expression and any sub-expression it depends match against a node and its children
+## Will return true if the expression and any sub-expression it depends on match against a GDNode and its children
 @abstract
 func matches(node: GDNode) -> bool
 
@@ -36,6 +43,11 @@ static func identifier(name: String, as_regex := false) -> GDIdentifierExpr:
 	return new_expr
 
 
+## Creates an expresion that will match any GDIdentifierNode
+static func any_identifier() -> GDIdentifierExpr:
+	return GDIdentifierExpr.new(".*", true)
+
+
 ## Creates an expression that will match a GDNode to a literal.
 ## If approx_equal is true, will use is_equal_approx, otherwise ==
 ## If ignore_value is true, will match with any literal node
@@ -50,11 +62,14 @@ static func assignment(assignee: GDExpr, assignment_expr: GDExpr, operation: GDA
 	return new_expr
 
 
+## Creates an expression that will match a GDIfNode and its contents
+## Providing either true/false blocks is optional, if you're only checking the condition
 static func if_block(condition: GDExpr, truth_block: GDExpr = null, false_block: GDExpr = null) -> GDIfExpr:
 	var new_expr := GDIfExpr.new(condition, truth_block, false_block)
 	return new_expr
 
 
+## Creates an expression that will match any GDNode that contains a single GDSuiteNode
 static func suite(...statements) -> GDSuiteExpr:
 	var new_expr := GDSuiteExpr.new(statements as Array)
 	return new_expr
@@ -65,6 +80,7 @@ static func any() -> GDAnyExpr:
 	return GDAnyExpr.new()
 
 
+## Creates an expression that will match one or more of the provided expressions
 static func any_of(...expressions) -> GDAnyOfExpr:
 	return GDAnyOfExpr.new(expressions as Array)
 

--- a/script_checking/ast_analyzer/GDExpr.gd
+++ b/script_checking/ast_analyzer/GDExpr.gd
@@ -79,8 +79,24 @@ static func if_block(condition: GDExpr, truth_block: GDExpr = null, false_block:
 
 
 ## Creates an expression that will match any GDNode that contains a single GDSuiteNode
+## Accepts one of:[br]
+## - SUITE: Directly access suite[br]
+## - FUNCTION: A function's body[br]
+## - FOR: The loop's body[br]
+## - WHILE: The loop's body[br]
+## - IDENTIFIER: The suite the identifier is part of[br]
+## - IF: The true block[br]
+## - MATCH_BRANCH: The block for the branch[br]
+## The order the statements appear is not importance, so long as they appear.
+## If the order matters, use [method strict_suite].
 static func suite(...statements) -> GDSuiteExpr:
-	var new_expr := GDSuiteExpr.new(statements as Array)
+	var new_expr := GDSuiteExpr.new(statements as Array, false)
+	return new_expr
+
+
+## As [method suite], but every statement is guaranteed to be positioned relative to the expressions' order.
+static func strict_suite(...statements) -> GDSuiteExpr:
+	var new_expr := GDSuiteExpr.new(statements as Array, true)
 	return new_expr
 
 

--- a/script_checking/ast_analyzer/GDExpr.gd
+++ b/script_checking/ast_analyzer/GDExpr.gd
@@ -1,17 +1,26 @@
 ## Expressions that are used to match against the parser's nodes
 ## e.g.
 ## [codeblock]
-## var process := _analyzer.get_function_named("_process")
-## if not GDExpr.suite(
+## var captures := {}
+## # func _process(delta):
+## if not GDExpr.function(
+## 	"_process",
+## 	GDExpr.suite(
+## 		# rotate(2.0 * delta)
 ## 		GDExpr.function_call(
 ## 			"rotate",
 ## 			GDExpr.multiply(
 ## 				GDExpr.literal(2.0),
-## 				GDExpr.identifier(process_delta_name)
+## 				GDExpr.captured_identifier("delta", captures)
 ## 			)
 ## 		)
-## 	).matches(process):
-## 		return tr("The rotation speed is not right. The robot should rotate 2 radians per second. Make sure the call looks like this: rotate(2 * delta).")
+## 	),
+## 	GDExpr.parameter(
+## 		# capture delta to be used with captured_identifier()
+## 		GDExpr.any_identifier().capture("delta", captures)
+## 	)
+## ).matches(process):
+## 	return tr("The rotation speed is not right. The robot should rotate 2 radians per second. Make sure the call looks like this: rotate(2 * %s)." % [captures.delta])
 ## [/codeblock]
 @abstract
 class_name GDExpr
@@ -95,14 +104,18 @@ static func function_call(name: StringName, ...arguments) -> GDCallExpr:
 	return new_expr
 
 
+## Creates an expression that will match against a for loop by any or all of its var, list, and suite
 static func for_loop(loop_variable: GDIdentifierExpr = null, list: GDExpr = null, body: GDSuiteExpr = null) -> GDForExpr:
 	return GDForExpr.new(loop_variable, list, body)
 
 
+## Creates an expression that will match against an identifier that was previously captured
+## See GDIdentifierExpr.capture()
 static func captured_identifier(name: StringName, captures: Dictionary) -> GDCaptureExpr:
 	return GDCaptureExpr.new(name, captures)
 
 
+## Creates an expression that will match against an array literal and any of its elements
 static func array(elements: Array) -> GDArrayExpr:
 	var new_elements: Array[GDExpr] = []
 	for element in elements:
@@ -111,283 +124,18 @@ static func array(elements: Array) -> GDArrayExpr:
 	return GDArrayExpr.new(new_elements)
 
 
-class GDArrayExpr extends GDExpr:
-	var _elements: Array[GDExpr]
-	
-	
-	func _init(elements: Array[GDExpr]) -> void:
-		_elements = elements
-	
-
-	func matches(node: GDNode) -> bool:
-		if node.get_type() != GDNode.ARRAY:
-			return false
-		var array_node := node as GDArrayNode
-		var elements := array_node.get_elements()
-		if elements.size() < _elements.size():
-			return false
-		for i in _elements.size():
-			if not _elements[i].matches(elements[i]):
-				return false
-		return true
+## Creates an expression that will match against an array or dictionary subscript access
+## E.g. my_array[6]
+static func subscript(base: GDExpr, index: GDExpr) -> GDSubscriptExpr:
+	return GDSubscriptExpr.new(base, index)
 
 
-class GDCaptureExpr extends GDIdentifierExpr:
-	func _init(name: StringName, captures: Dictionary) -> void:
-		_name = name
-		_captures = captures
-	
-	
-	func matches(node: GDNode) -> bool:
-		if node.get_type() != GDNode.IDENTIFIER:
-			return false
-		var ident_node := node as GDIdentifierNode
-		return ident_node.name == _captures[_name]
+## Creates an expression that will match against a function by its name, body and parameters
+## Pass in null for any parameter you do not want to check against
+static func function(name: StringName, body: GDSuiteExpr = null, ...parameters) -> GDFunctionExpr:
+	return GDFunctionExpr.new(name, parameters as Array, body)
 
 
-class GDForExpr extends GDExpr:
-	var _loop_variable: GDExpr
-	var _body: GDExpr
-	var _list: GDExpr
-	
-	func _init(loop_variable: GDIdentifierExpr = null, list: GDExpr = null, body: GDSuiteExpr = null) -> void:
-		_loop_variable = loop_variable
-		_body = body
-		_list = list
-	
-	
-	func matches(node: GDNode) -> bool:
-		if node.get_type() != GDNode.FOR:
-			return false
-		var for_node := node as GDForNode
-		if (
-			(_loop_variable and not _loop_variable.matches(for_node.get_variable())) or
-			(_list and not _list.matches(for_node.get_list())) or
-			(_body and not _body.matches(for_node.get_loop()))
-		):
-			return false
-		return true
-
-
-class GDAnyOfExpr extends GDExpr:
-	var _expressions: Array[GDExpr] = []
-	
-	func _init(expressions: Array) -> void:
-		for expression in expressions:
-			assert(expression is GDExpr, "Can only accept GDExpr types")
-			_expressions.push_back(expression)
-	
-	
-	func matches(node: GDNode) -> bool:
-		return _expressions.any(func(expression: GDExpr) -> bool: return expression.matches(node))
-
-
-class GDSuiteExpr extends GDExpr:
-	var _statements: Array[GDExpr] = []
-	
-	func _init(statements: Array) -> void:
-		for statement: GDExpr in statements:
-			assert(statement, "Can only accept GDExpr arguments")
-			_statements.push_back(statement)
-	
-
-	func matches(node: GDNode) -> bool:
-		var suite_node: GDSuiteNode = null
-		if node.get_type() == GDNode.FUNCTION:
-			suite_node = (node as GDFunctionNode).get_body()
-		elif node.get_type() == GDNode.SUITE:
-			suite_node = node as GDSuiteNode
-		else:
-			return false
-		
-		var suite_statements := suite_node.get_statements()
-		
-		for statement_expression: GDExpr in _statements:
-			var found_match := false
-			for suite_statement: GDNode in suite_statements:
-				if statement_expression.matches(suite_statement):
-					found_match = true
-					break
-			if not found_match:
-				return false
-		return true
-
-
-class GDIfExpr extends GDExpr:
-	var _condition: GDExpr
-	var _truth_block: GDExpr
-	var _false_block: GDExpr
-	
-	func _init(condition: GDExpr, truth_block: GDExpr = null, false_block: GDExpr = null) -> void:
-		_condition = condition
-		_truth_block = truth_block
-		_false_block = false_block
-	
-	
-	func matches(node: GDNode) -> bool:
-		if node.get_type() != GDNode.IF:
-			return false
-		var if_node := node as GDIfNode
-		
-		return (
-			_condition.matches(if_node.get_condition()) and
-			(not _truth_block or _truth_block.matches(if_node.get_true_block())) and
-			(not _false_block or _false_block.matches(if_node.get_false_block()))
-		)
-
-
-class GDAssignExpr extends GDExpr:
-	var _assignee: GDExpr
-	var _operation: GDAssignmentNode.Operation
-	var _assignment_expr: GDExpr
-	
-	func _init(assignee: GDExpr, assignment_expr: GDExpr, operation: GDAssignmentNode.Operation) -> void:
-		_assignee = assignee
-		_assignment_expr = assignment_expr
-		_operation = operation
-
-
-	func matches(node: GDNode) -> bool:
-		if node.get_type() != GDNode.ASSIGNMENT:
-			return false
-		var assignment_node := node as GDAssignmentNode
-		return assignment_node.get_operation() == _operation and _assignee.matches(assignment_node.get_assignee()) and _assignment_expr.matches(assignment_node.get_assigned_value())
-
-
-
-class GDAnyExpr extends GDExpr:
-	func matches(_node: GDNode) -> bool:
-		return true
-
-
-class GDCallExpr extends GDExpr:
-	var _name: StringName
-	var _arguments: Array[GDExpr]
-	
-	func _init(name: StringName, arguments: Array[GDExpr]) -> void:
-		_name = name
-		_arguments = arguments
-
-
-	func matches(node: GDNode) -> bool:
-		if node.get_type() != GDNode.CALL:
-			return false
-		var call_node := node as GDCallNode
-		if call_node.get_function_name() != _name:
-			return false
-		var call_arguments := call_node.get_arguments()
-		if call_arguments.size() < _arguments.size():
-			return false
-		for i in _arguments.size():
-			var argument: GDExpr = _arguments[i]
-			if argument == null:
-				continue
-			if not argument.matches(call_arguments[i]):
-				return false
-		return call_node.get_function_name() == _name
-
-
-class GDLiteralExpr extends GDExpr:
-	var _value: Variant
-	var _any_value := false
-	var _approx := false
-
-
-	func _init(value: Variant, approx: bool, any_value: bool) -> void:
-		_value = value
-		_any_value = any_value
-		_approx = approx
-
-
-	func matches(node: GDNode) -> bool:
-		if node.get_type() != GDNode.LITERAL:
-			return false
-		if _any_value:
-			return true
-		var lit_node := node as GDLiteralNode
-		if _approx:
-			if _value is float and lit_node.get_value() is float:
-				return is_equal_approx(lit_node.value as float, _value as float)
-			elif _value is AABB and lit_node.get_value() is AABB:
-				return (_value as AABB).is_equal_approx(lit_node.get_value() as AABB)
-			elif _value is Basis and lit_node.get_value() is Basis:
-				return (_value as Basis).is_equal_approx(lit_node.get_value() as Basis)
-			elif _value is Color and lit_node.get_value() is Color:
-				return (_value as Color).is_equal_approx(lit_node.get_value() as Color)
-			elif _value is Plane and lit_node.get_value() is Plane:
-				return (_value as Plane).is_equal_approx(lit_node.get_value() as Plane)
-			elif _value is Quaternion and lit_node.get_value() is Quaternion:
-				return (_value as Quaternion).is_equal_approx(lit_node.get_value() as Quaternion)
-			elif _value is Rect2 and lit_node.get_value() is Rect2:
-				return (_value as Rect2).is_equal_approx(lit_node.get_value() as Rect2)
-			elif _value is Transform2D and lit_node.get_value() is Transform2D:
-				return (_value as Transform2D).is_equal_approx(lit_node.get_value() as Transform2D)
-			elif _value is Transform3D and lit_node.get_value() is Transform3D:
-				return (_value as Transform3D).is_equal_approx(lit_node.get_value() as Transform3D)
-			elif _value is Vector2 and lit_node.get_value() is Vector2:
-				return (_value as Vector2).is_equal_approx(lit_node.get_value() as Vector2)
-			elif _value is Vector3 and lit_node.get_value() is Vector3:
-				return (_value as Vector3).is_equal_approx(lit_node.get_value() as Vector3)
-			elif _value is Vector4 and lit_node.get_value() is Vector4:
-				return (_value as Vector4).is_equal_approx(lit_node.get_value() as Vector4)
-		var value: Variant = lit_node.value
-		return value == _value
-
-
-class GDIdentifierExpr extends GDExpr:
-	var _name: String
-	var _regex: RegEx = null
-	var _do_capture := false
-	var _capture_name: StringName
-	var _captures: Dictionary
-
-	func _init(name: String, use_regex: bool) -> void:
-		_name = name
-		if use_regex:
-			_regex = RegEx.create_from_string(name)
-
-
-	func matches(node: GDNode) -> bool:
-		if node.get_type() != GDNode.IDENTIFIER:
-			return false
-		
-		var ident_node := node as GDIdentifierNode
-		var does_match := false
-		if _regex:
-			does_match = _regex.search(ident_node.name) != null
-		else:
-			does_match = ident_node.name == _name
-		if _do_capture:
-			_captures[_capture_name] = ident_node.name
-		return does_match
-
-
-	func capture(name: StringName, captures: Dictionary) -> GDIdentifierExpr:
-		_capture_name = name
-		_captures = captures
-		_captures[_capture_name] = &""
-		_do_capture = true
-		return self
-
-
-class GDBinaryOpExpr extends GDExpr:
-	var _operands: Array[GDExpr] = []
-	var _strict_order := false
-	var _type: GDBinaryOpNode.OpType
-	
-	func _init(operand_a: GDExpr, operand_b: GDExpr, type: GDBinaryOpNode.OpType, strict_order: bool) -> void:
-		_operands = [operand_a, operand_b]
-		_strict_order = strict_order
-		_type = type
-
-
-	func matches(node: GDNode) -> bool:
-		if node.get_type() != GDNode.BINARY_OPERATOR:
-			return false
-		var binary_op := node as GDBinaryOpNode
-		if binary_op.operation != _type:
-			return false
-		var does_match := _operands[0].matches(binary_op.left) and _operands[1].matches(binary_op.right)
-		if not does_match and not _strict_order:
-			does_match = _operands[1].matches(binary_op.left) and _operands[0].matches(binary_op.right)
-		return does_match
+## Creates an expression that will match against a parameter by its name and optionally its default value
+static func parameter(parameter_identifier: GDIdentifierExpr, initializer: GDExpr = null) -> GDParameterExpr:
+	return GDParameterExpr.new(parameter_identifier, initializer)

--- a/script_checking/ast_analyzer/GDExpr.gd.uid
+++ b/script_checking/ast_analyzer/GDExpr.gd.uid
@@ -1,0 +1,1 @@
+uid://bgvga1luo2btg

--- a/script_checking/ast_analyzer/GDForExpr.gd
+++ b/script_checking/ast_analyzer/GDForExpr.gd
@@ -1,0 +1,25 @@
+class_name GDForExpr
+extends GDExpr
+
+
+var _loop_variable: GDExpr
+var _body: GDExpr
+var _list: GDExpr
+
+func _init(loop_variable: GDIdentifierExpr = null, list: GDExpr = null, body: GDSuiteExpr = null) -> void:
+	_loop_variable = loop_variable
+	_body = body
+	_list = list
+
+
+func matches(node: GDNode) -> bool:
+	if node.get_type() != GDNode.FOR:
+		return false
+	var for_node := node as GDForNode
+	if (
+		(_loop_variable and not _loop_variable.matches(for_node.get_variable())) or
+		(_list and not _list.matches(for_node.get_list())) or
+		(_body and not _body.matches(for_node.get_loop()))
+	):
+		return false
+	return true

--- a/script_checking/ast_analyzer/GDForExpr.gd.uid
+++ b/script_checking/ast_analyzer/GDForExpr.gd.uid
@@ -1,0 +1,1 @@
+uid://bj0thl5ylxjc7

--- a/script_checking/ast_analyzer/GDFunctionExpr.gd
+++ b/script_checking/ast_analyzer/GDFunctionExpr.gd
@@ -1,0 +1,36 @@
+class_name GDFunctionExpr
+extends GDExpr
+
+
+var _name: StringName
+var _body: GDSuiteExpr
+var _parameters: Array[GDParameterExpr]
+
+
+func _init(name: StringName, parameters: Array, body: GDSuiteExpr = null) -> void:
+	_name = name
+	_parameters = []
+	for function_parameter in parameters:
+		assert(function_parameter is GDParameterExpr, "Can only accept GDParameterExpr")
+		_parameters.push_back(function_parameter)
+	_body = body
+
+
+func matches(node: GDNode) -> bool:
+	if node.get_type() != GDNode.FUNCTION:
+		return false
+	var function_node := node as GDFunctionNode
+	if function_node.get_identifier().name != _name:
+		return false
+	var local_parameters := function_node.get_parameters()
+	if local_parameters.size() < _parameters.size():
+		return false
+	for i in _parameters.size():
+		var function_parameter := _parameters[i]
+		if not function_parameter:
+			continue
+		if not function_parameter.matches(local_parameters[i]):
+			return false
+	if _body and not _body.matches(function_node.get_body()):
+		return false
+	return true

--- a/script_checking/ast_analyzer/GDFunctionExpr.gd.uid
+++ b/script_checking/ast_analyzer/GDFunctionExpr.gd.uid
@@ -1,0 +1,1 @@
+uid://cayft67pm6xts

--- a/script_checking/ast_analyzer/GDIdentifierExpr.gd
+++ b/script_checking/ast_analyzer/GDIdentifierExpr.gd
@@ -1,0 +1,55 @@
+class_name GDIdentifierExpr
+extends GDExpr
+
+
+var _name: String
+var _regex: RegEx = null
+var _do_capture := false
+var _capture_name: StringName
+var _captures: Dictionary
+
+func _init(name: String, use_regex: bool) -> void:
+	_name = name
+	if use_regex:
+		_regex = RegEx.create_from_string(name)
+
+
+func matches(node: GDNode) -> bool:
+	if node.get_type() != GDNode.IDENTIFIER:
+		return false
+	
+	var ident_node := node as GDIdentifierNode
+	var does_match := false
+	if _regex:
+		does_match = _regex.search(ident_node.name) != null
+	else:
+		does_match = ident_node.name == _name
+	if _do_capture:
+		_captures[_capture_name] = ident_node.name
+	return does_match
+
+
+## Captures the identifier. This will prime the `captures` dictionary with the capture `name`.
+## When the node is matched in `matches()`, its identifier name will be stored.
+## GDCaptureExpr can then match against it by its capture name instead of its real identifier name.
+## [codeblock]
+## var captures := {}
+## # for item_name in inventory:
+## if GDExpr.for_loop(
+## 	GDExpr.any_identifier().capture("item_name", captures),
+## 	GDExpr.identifier("inventory"),
+## 	GDExpr.suite(
+## 		# print(item_name)
+## 		GDExpr.function_call(
+## 			"print",
+## 			GDExpr.captured_identifier("item_name", captures)
+## 		)
+## 	)
+## ).matches(for_statement):
+## [/codeblock]
+func capture(name: StringName, captures: Dictionary) -> GDIdentifierExpr:
+	_capture_name = name
+	_captures = captures
+	_captures[_capture_name] = &""
+	_do_capture = true
+	return self

--- a/script_checking/ast_analyzer/GDIdentifierExpr.gd.uid
+++ b/script_checking/ast_analyzer/GDIdentifierExpr.gd.uid
@@ -1,0 +1,1 @@
+uid://diujbk0qc45kf

--- a/script_checking/ast_analyzer/GDIfExpr.gd
+++ b/script_checking/ast_analyzer/GDIfExpr.gd
@@ -1,0 +1,24 @@
+class_name GDIfExpr
+extends GDExpr
+
+
+var _condition: GDExpr
+var _truth_block: GDExpr
+var _false_block: GDExpr
+
+func _init(condition: GDExpr, truth_block: GDExpr = null, false_block: GDExpr = null) -> void:
+	_condition = condition
+	_truth_block = truth_block
+	_false_block = false_block
+
+
+func matches(node: GDNode) -> bool:
+	if node.get_type() != GDNode.IF:
+		return false
+	var if_node := node as GDIfNode
+	
+	return (
+		_condition.matches(if_node.get_condition()) and
+		(not _truth_block or _truth_block.matches(if_node.get_true_block())) and
+		(not _false_block or _false_block.matches(if_node.get_false_block()))
+	)

--- a/script_checking/ast_analyzer/GDIfExpr.gd.uid
+++ b/script_checking/ast_analyzer/GDIfExpr.gd.uid
@@ -1,0 +1,1 @@
+uid://yrle33epjqmt

--- a/script_checking/ast_analyzer/GDLiteralExpr.gd
+++ b/script_checking/ast_analyzer/GDLiteralExpr.gd
@@ -1,0 +1,48 @@
+class_name GDLiteralExpr
+extends GDExpr
+
+
+var _value: Variant
+var _any_value := false
+var _approx := false
+
+
+func _init(value: Variant, approx: bool, any_value: bool) -> void:
+	_value = value
+	_any_value = any_value
+	_approx = approx
+
+
+func matches(node: GDNode) -> bool:
+	if node.get_type() != GDNode.LITERAL:
+		return false
+	if _any_value:
+		return true
+	var lit_node := node as GDLiteralNode
+	if _approx:
+		if _value is float and lit_node.get_value() is float:
+			return is_equal_approx(lit_node.value as float, _value as float)
+		elif _value is AABB and lit_node.get_value() is AABB:
+			return (_value as AABB).is_equal_approx(lit_node.get_value() as AABB)
+		elif _value is Basis and lit_node.get_value() is Basis:
+			return (_value as Basis).is_equal_approx(lit_node.get_value() as Basis)
+		elif _value is Color and lit_node.get_value() is Color:
+			return (_value as Color).is_equal_approx(lit_node.get_value() as Color)
+		elif _value is Plane and lit_node.get_value() is Plane:
+			return (_value as Plane).is_equal_approx(lit_node.get_value() as Plane)
+		elif _value is Quaternion and lit_node.get_value() is Quaternion:
+			return (_value as Quaternion).is_equal_approx(lit_node.get_value() as Quaternion)
+		elif _value is Rect2 and lit_node.get_value() is Rect2:
+			return (_value as Rect2).is_equal_approx(lit_node.get_value() as Rect2)
+		elif _value is Transform2D and lit_node.get_value() is Transform2D:
+			return (_value as Transform2D).is_equal_approx(lit_node.get_value() as Transform2D)
+		elif _value is Transform3D and lit_node.get_value() is Transform3D:
+			return (_value as Transform3D).is_equal_approx(lit_node.get_value() as Transform3D)
+		elif _value is Vector2 and lit_node.get_value() is Vector2:
+			return (_value as Vector2).is_equal_approx(lit_node.get_value() as Vector2)
+		elif _value is Vector3 and lit_node.get_value() is Vector3:
+			return (_value as Vector3).is_equal_approx(lit_node.get_value() as Vector3)
+		elif _value is Vector4 and lit_node.get_value() is Vector4:
+			return (_value as Vector4).is_equal_approx(lit_node.get_value() as Vector4)
+	var value: Variant = lit_node.value
+	return value == _value

--- a/script_checking/ast_analyzer/GDLiteralExpr.gd.uid
+++ b/script_checking/ast_analyzer/GDLiteralExpr.gd.uid
@@ -1,0 +1,1 @@
+uid://bh03tiusrkoxm

--- a/script_checking/ast_analyzer/GDParameterExpr.gd
+++ b/script_checking/ast_analyzer/GDParameterExpr.gd
@@ -1,0 +1,21 @@
+class_name GDParameterExpr
+extends GDExpr
+
+
+var _identifier: GDIdentifierExpr
+var _initializer: GDExpr
+
+func _init(parameter_identifier: GDIdentifierExpr, initializer: GDExpr = null) -> void:
+	_identifier = parameter_identifier
+	_initializer  = initializer
+
+
+func matches(node: GDNode) -> bool:
+	if node.get_type() != GDNode.PARAMETER:
+		return false
+	var parameter_node := node as GDParameterNode
+	if not _identifier.matches(parameter_node.get_identifier()):
+		return false
+	if _initializer and not _initializer.matches(parameter_node.get_initializer()):
+		return false
+	return true

--- a/script_checking/ast_analyzer/GDParameterExpr.gd.uid
+++ b/script_checking/ast_analyzer/GDParameterExpr.gd.uid
@@ -1,0 +1,1 @@
+uid://unap1rpho3lq

--- a/script_checking/ast_analyzer/GDSubscriptExpr.gd
+++ b/script_checking/ast_analyzer/GDSubscriptExpr.gd
@@ -1,0 +1,18 @@
+class_name GDSubscriptExpr
+extends GDExpr
+
+
+var _index: GDExpr
+var _base: GDExpr
+
+func _init(base: GDExpr, index: GDExpr) -> void:
+	_index = index
+	_base = base
+
+
+func matches(node: GDNode) -> bool:
+	if node.get_type() != GDNode.SUBSCRIPT:
+		return false
+	var subscript_node := node as GDSubscriptNode
+	
+	return _index.matches(subscript_node.get_as_index()) and _base.matches(subscript_node.get_base())

--- a/script_checking/ast_analyzer/GDSubscriptExpr.gd.uid
+++ b/script_checking/ast_analyzer/GDSubscriptExpr.gd.uid
@@ -1,0 +1,1 @@
+uid://bjimqghr2yh2o

--- a/script_checking/ast_analyzer/GDSuiteExpr.gd
+++ b/script_checking/ast_analyzer/GDSuiteExpr.gd
@@ -3,8 +3,12 @@ extends GDExpr
 
 
 var _statements: Array[GDExpr] = []
+var _strict_order: bool
 
-func _init(statements: Array) -> void:
+
+func _init(statements: Array, strict_order: bool) -> void:
+	_strict_order = strict_order
+	
 	for statement: GDExpr in statements:
 		assert(statement, "Can only accept GDExpr arguments")
 		_statements.push_back(statement)
@@ -12,21 +16,40 @@ func _init(statements: Array) -> void:
 
 func matches(node: GDNode) -> bool:
 	var suite_node: GDSuiteNode = null
-	if node.get_type() == GDNode.FUNCTION:
-		suite_node = (node as GDFunctionNode).get_body()
-	elif node.get_type() == GDNode.SUITE:
-		suite_node = node as GDSuiteNode
-	else:
-		return false
+	match node.get_type():
+		GDNode.SUITE:
+			suite_node = node as GDSuiteNode
+		GDNode.FUNCTION:
+			suite_node = (node as GDFunctionNode).get_body()
+		GDNode.FOR:
+			suite_node = (node as GDForNode).get_loop()
+		GDNode.WHILE:
+			suite_node = (node as GDWhileNode).get_loop()
+		GDNode.IDENTIFIER:
+			suite_node = (node as GDIdentifierNode).get_suite()
+		GDNode.IF:
+			suite_node = (node as GDIfNode).get_true_block()
+		GDNode.MATCH_BRANCH:
+			suite_node = (node as GDMatchBranchNode).get_block()
+		_:
+			return false
 	
 	var suite_statements := suite_node.get_statements()
+	var indices := []
 	
 	for statement_expression: GDExpr in _statements:
 		var found_match := false
-		for suite_statement: GDNode in suite_statements:
+		for i in suite_statements.size():
+			var suite_statement: GDNode = suite_statements[i]
 			if statement_expression.matches(suite_statement):
+				indices.push_back(i)
 				found_match = true
 				break
 		if not found_match:
 			return false
+	if _strict_order:
+		var previous: int = indices[0]
+		for i in range(1, indices.size()):
+			if indices[i] < previous:
+				return false
 	return true

--- a/script_checking/ast_analyzer/GDSuiteExpr.gd
+++ b/script_checking/ast_analyzer/GDSuiteExpr.gd
@@ -1,0 +1,32 @@
+class_name GDSuiteExpr
+extends GDExpr
+
+
+var _statements: Array[GDExpr] = []
+
+func _init(statements: Array) -> void:
+	for statement: GDExpr in statements:
+		assert(statement, "Can only accept GDExpr arguments")
+		_statements.push_back(statement)
+
+
+func matches(node: GDNode) -> bool:
+	var suite_node: GDSuiteNode = null
+	if node.get_type() == GDNode.FUNCTION:
+		suite_node = (node as GDFunctionNode).get_body()
+	elif node.get_type() == GDNode.SUITE:
+		suite_node = node as GDSuiteNode
+	else:
+		return false
+	
+	var suite_statements := suite_node.get_statements()
+	
+	for statement_expression: GDExpr in _statements:
+		var found_match := false
+		for suite_statement: GDNode in suite_statements:
+			if statement_expression.matches(suite_statement):
+				found_match = true
+				break
+		if not found_match:
+			return false
+	return true

--- a/script_checking/ast_analyzer/GDSuiteExpr.gd.uid
+++ b/script_checking/ast_analyzer/GDSuiteExpr.gd.uid
@@ -1,0 +1,1 @@
+uid://0li7pncwuuwe

--- a/ui/UIPractice.gd
+++ b/ui/UIPractice.gd
@@ -303,12 +303,28 @@ func _validate_and_run_student_code() -> void:
 		MessageBus.print_script_error(error, script_file_name)
 		_code_editor.unlock_editor()
 		return
+	
+	var verifier_script := script_text
+	var script_is_desynced_by_one_line := false
+
+	if not _has_class_name(verifier_script):
+		# GDScriptAnalyzer needs a path or class_name. As we're feeding code directly into the parser,
+		# we can't really have a path, so we need a class_name to fool it
+		var initial_insertion_character := _find_first_non_annotation_entry_point(verifier_script)
+		verifier_script = verifier_script.insert(initial_insertion_character, "class_name TEMP_UserScript\n")
+		script_is_desynced_by_one_line = true
+
+	var verifier := OfflineScriptVerifier.new(verifier_script)
 
 	# Do local sanity checks for the script.
-	var tokenizer := MiniGDScriptTokenizer.new(script_text)
+	var analyzer: GDScriptLocalAnalyzer = null
+	if ClassDB.class_exists(OfflineScriptVerifier.PARSE_WRAPPER_CLASS):
+		analyzer = GDScriptASTAnalyzer.new(verifier.get_class_ast())
+	else:
+		analyzer = MiniGDScriptTokenizer.new(verifier_script)
 
 	# Check for recursive functions
-	var recursive_function := tokenizer.find_any_recursive_function()
+	var recursive_function := analyzer.find_any_recursive_function()
 	if recursive_function != "":
 		var error := ScriptError.new()
 		error.message = (
@@ -321,7 +337,7 @@ func _validate_and_run_student_code() -> void:
 		_code_editor.unlock_editor()
 		return
 	# Check for infinite while loops
-	if tokenizer.has_infinite_while_loop():
+	if analyzer.has_infinite_while_loop():
 		var error := ScriptError.new()
 		error.message = tr(
 			"You have a while loop that runs forever (while true) without a break statement. This will freeze the app.",
@@ -331,18 +347,7 @@ func _validate_and_run_student_code() -> void:
 		MessageBus.print_script_error(error, script_file_name)
 		_code_editor.unlock_editor()
 		return
-
-	var verifier_script := script_text
-	var script_is_desynced_by_one_line := false
-
-	if not _has_class_name(verifier_script):
-		# GDScriptAnalyzer needs a path or class_name. As we're feeding code directly into the parser,
-		# we can't really have a path, so we need a class_name to fool it
-		var initial_insertion_character := _find_first_non_annotation_entry_point(verifier_script)
-		verifier_script = verifier_script.insert(initial_insertion_character, "class_name TEMP_UserScript\n")
-		script_is_desynced_by_one_line = true
-
-	var verifier := OfflineScriptVerifier.new(verifier_script)
+	
 	verifier.test()
 	var errors := verifier.errors
 


### PR DESCRIPTION
As outlined in #1281, it is difficult and error prone to use RegEx to analyze code patterns, especially as they get increasingly complex, or if you need to check an entire function or for loop for correctness.

I'm opening this PR to seek out a bit of feedback, since it's an entirely new API to be introduced and consumed.

Fixes #1281 

This PR has two parts:

## C++
https://github.com/Razoric480/godot/tree/raz/expose-parser would get merged into the custom godot engine's main 4.6.x branch we're compiling from and a new release made (can maybe upgrade to 4.6.3 while we're at it, but that's separate.)

This takes all of the parser nodes that are produced by the GDScriptParser class and exposes them as custom GD<NodeType> RefCounted, which can then redirect all of their various outputs via `get_<data>()` function. like `GDIdentifier::get_name()` to get a StringName. This root class can then be grabbed from the GDScriptErrorChecker, calling `get_root_parse_node()` after calling `set_source()`.

While it's possible to directly access them from the `get_root_parse_node()` and analyze the contents, it's not exactly super friendly to use. Ergo:

## GDScript component
This adds the GDScriptASTAnalyzer and the GDExpr API.

The analyzer gives some high level node fetching, like `get_function_named()`, whereas the GDExpr API allows for complex and complete analysis to make sure the code it received matches some expected output by writing a set of nested expressions.

Example simple:
```gdscript
var run_function := _analyzer.get_function_named("run")
	
if not GDExpr.suite(
	GDExpr.for_loop(
		GDExpr.any_identifier(),
		GDExpr.identifier("inventory"),
	)
).matches(run_function):
	return tr("Your code has no for loop. You need to use a for loop to complete this practice, even if there are other solutions!")
```

Example more complex:
```gdscript
var process := _analyzer.get_function_named(&"_process")
var captures := {}
# func _process(delta):
if not GDExpr.function(
	&"_process",
	GDExpr.suite(
		# rotate(2.0 * delta)
		GDExpr.function_call(
			&"rotate",
			GDExpr.multiply(
				GDExpr.literal(2.0),
				GDExpr.captured_identifier(&"delta", captures)
			)
		)
	),
	GDExpr.parameter(
		# capture delta to be used with captured_identifier()
		GDExpr.any_identifier().capture(&"delta", captures)
	)
).matches(process):
	return tr("The rotation speed is not right. The robot should rotate 2 radians per second. Make sure the call looks like this: rotate(2 * %s)." % [captures.delta])
```

Not all nodes are exposed yet but as they are needed, more can be added since it's just a simple abstract inheritance (GDExpr).