### PR TITLE
ci: disable Jekyll processing for GitHub Pages deployment

### DIFF
--- a/.github/workflows/ExportGodot.yaml
+++ b/.github/workflows/ExportGodot.yaml
@@ -122,6 +122,9 @@ jobs:
           name: build-web
           path: build/web
 
+      - name: Disable Jekyll processing
+        run: touch build/web/.nojekyll
+        
       - name: Deploy release web build
         if: github.ref_name == 'release'
         # 4.8.0 pinned commit


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- [ ] For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #1364

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

CI/deployment fix for the GitHub Pages web build. Adds `.nojekyll` to the web deployment output to prevent GitHub Pages from processing the build with Jekyll.

**Does this PR introduce a breaking change?**

No.

## New feature or change ##

Adds a `.nojekyll` file to the exported web build before deploying to GitHub Pages.

**What is the current behavior?**

GitHub Pages runs Jekyll processing on the deployed web build, which can cause issues with Godot web export files and static assets.

**What is the new behavior?**

The deployed web build disables Jekyll processing by including a `.nojekyll` file, ensuring GitHub Pages serves the Godot export files as-is.

**Other information**

closes https://github.com/GDQuest/learn-gdscript/issues/1364
