### PR TITLE
Fix: Accept additional correct solutions in L14.P2 damage check

### DIFF
--- a/course/lesson-14-multiplying/reducing_damage/TestReducingDamage.gd
+++ b/course/lesson-14-multiplying/reducing_damage/TestReducingDamage.gd
@@ -70,6 +70,21 @@ func test_multiplication_is_used_to_reduce_damage_amount() -> String:
 							GDExpr.identifier(parameter_name),
 							GDExpr.literal(0.5)
 						)
+					),
+					# amount -= amount * 0.5
+					GDExpr.assignment(
+						GDExpr.identifier(parameter_name),
+						GDExpr.multiply(
+							GDExpr.identifier(parameter_name),
+							GDExpr.literal(0.5)
+						),
+						GDAssignmentNode.Operation.OP_SUBTRACTION
+					),
+					# amount /= 2
+					GDExpr.assignment(
+						GDExpr.identifier(parameter_name),
+						GDExpr.literal(2),
+						GDAssignmentNode.Operation.OP_DIVISION
 					)
 				)
 			)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #1388

**What kind of change does this PR introduce?**

Bug fix: widens the static check for practice L14.P2 "Reducing damage at
higher levels" so it accepts more correct solutions.

**Does this PR introduce a breaking change?**

No. All previously accepted solutions still pass; the change only adds
alternatives to the existing `GDExpr.any_of` pattern in
`TestReducingDamage.gd`. No practice text or error messages were touched,
so there is no translation churn.

## New feature or change ##

**What is the current behavior?**

The check "Multiplication Is Used To Reduce Damage Amount" only matches
`amount *= 0.5` and `amount = amount * 0.5` (operand order is already
flexible, so `amount = 0.5 * amount` also passes). Other solutions that
produce exactly the specified behavior, half damage above level 2, full
damage below, fail with "It looks like amount isn't reduced by a
percentage," even though the behavioral check passes.

**What is the new behavior?**

Two additional forms are accepted, both of which keep the practice's
intent of assigning the reduced value back to the parameter:

- `amount -= amount * 0.5`
- `amount /= 2` (also matches `2.0`, since literal matching uses Variant `==`)

**Out of scope, up to the maintainer**
- Reducing at the subtraction site (`health -= amount * 0.5` with an
  `else` branch which is the exact code from #1388): accepting it would drop the
  assign-to-parameter requirement entirely, which is a lesson-design call
  for a practice about multiplication.
- `amount = amount / 2`: easy to add with `GDExpr.bin_op(..., OP_DIVISION)`
  if wanted.
